### PR TITLE
Session changes

### DIFF
--- a/UT4MasterServerDotNetCore/Controllers/SessionController.cs
+++ b/UT4MasterServerDotNetCore/Controllers/SessionController.cs
@@ -39,6 +39,7 @@ namespace UT4MasterServer.Controllers
 			[FromForm(Name = "grant_type")] string grantType,
 			[FromForm(Name = "includePerms")] bool? includePerms,
 			[FromForm(Name = "code")] string? code,
+			[FromForm(Name = "refresh_token")] string? refreshToken,
 			[FromForm(Name = "username")] string? username,
 			[FromForm(Name = "password")] string? password)
 		{
@@ -58,7 +59,13 @@ namespace UT4MasterServer.Controllers
 							session = await sessionService.CreateSessionAsync(codeAuth.AccountID, clientID, SessionCreationMethod.AuthorizationCode);
 					}
 					break;
-				case "exchange_code":
+                case "refresh_token":
+					if (refreshToken != null)
+					{
+						session = await sessionService.RefreshSessionAsync(refreshToken);
+					}
+					break;
+                case "exchange_code":
 					if (code != null)
 					{
 						var codeExchange = await sessionService.TakeCodeAsync(CodeKind.Exchange, code);

--- a/UT4MasterServerDotNetCore/Models/Session.cs
+++ b/UT4MasterServerDotNetCore/Models/Session.cs
@@ -1,11 +1,5 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UT4MasterServer.Models
 {
@@ -73,6 +67,11 @@ namespace UT4MasterServer.Models
 				default:
 					throw new ArgumentException("invalid sessionType");
 			}
+		}
+
+		public bool HasExpired
+		{
+			get { return AccessToken.HasExpired; }
 		}
 	}
 }


### PR DESCRIPTION
- support for token refresh
- reject duplicate usernames on signup
- invalidate expired sessions

This is based on 41bcaf7d3347e06c28f5104561b8b101d2652426 because b1b5b9746390e2d72a74deb289cd1c991082d847 was throwing in `EpicIDSerializationProvider`. Had to change the parameter type on `GetAccount` to a `string` since it always returns null for the serializer. Not sure what I need to do to fix that.