### PR TITLE
Full cloudstorage support

### DIFF
--- a/UT4MasterServerDotNetCore/Controllers/CloudStorageController.cs
+++ b/UT4MasterServerDotNetCore/Controllers/CloudStorageController.cs
@@ -1,49 +1,107 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
 using UT4MasterServer.Authorization;
+using UT4MasterServer.Models;
 using UT4MasterServer.Services;
 
 namespace UT4MasterServer.Controllers
 {
     [ApiController]
-    [Route("ut/api/cloudstorage/user/")]
+    [Route("ut/api/cloudstorage")]
     [AuthorizeBearer]
-    [Produces("application/json")]
-    public class CloudStorageController : JsonAPIController
+	[Produces("application/octet-stream")]
+	public class CloudstorageController : JsonAPIController
 	{
         private readonly ILogger<SessionController> logger;
-        private readonly AccountService accountService;
         private readonly SessionService sessionService;
+		private readonly CloudstorageService cloudstorageService;
 
-        public CloudStorageController(SessionService sessionService, AccountService accountService, AccountDataService accountDataService, ILogger<SessionController> logger)
+		public CloudstorageController(SessionService sessionService, CloudstorageService cloudstorageService, ILogger<SessionController> logger)
         {
             this.sessionService = sessionService;
-            this.accountService = accountService;
+            this.cloudstorageService = cloudstorageService;
             this.logger = logger;
         }
 
-        [HttpGet("{id}")]
-        public IActionResult Get(string id)
+        [HttpGet("user/{id}")]
+        public async Task<IActionResult> ListUserfiles(string id)
         {
-            return new NoContentResult();
+			// list all files this user has in storage - any user can see files from another user
+
+			/* [
+			
+            {"uniqueFilename":"user_progression_1",
+            "filename":"user_progression_1",
+            "hash":"32a17bdf348e653a5cc7f94c3afb404301502d43",
+            "hash256":"7dcfaac101dbba0337e1b51bf3c088e591742d5f1c299f10cc0c9da01eab5fe8",
+            "length":21,
+            "contentType":"text/plain",
+            "uploaded":"2020-05-24T07:10:43.198Z",
+            "storageType":"S3",
+            "accountId":"64bf8c6d81004e88823d577abe157373"
+            },
+            ]
+			
+			
+			*/
+
+			var files = await cloudstorageService.ListFilesAsync(EpicID.FromString(id));
+
+			var arr = new JArray();
+			foreach (var file in files)
+			{
+				var obj = new JObject();
+				obj.Add("uniqueFilename", file.Filename);
+				obj.Add("filename", file.Filename);
+				obj.Add("hash", file.Hash);
+				obj.Add("hash256", file.Hash256);
+				obj.Add("length", file.Length);
+				obj.Add("contentType", "text/plain"); // this seems to be constant
+				obj.Add("uploaded", file.UploadedAt.ToStringISO());
+				obj.Add("storageType", "S3");
+				obj.Add("accountId", id);
+				arr.Add(obj);
+			}
+
+			return Json(arr);
         }
 
-        [HttpGet("{id}/user_profile_2")]
-        [Produces("application/octet-stream")]
-        public async Task<IActionResult> QueryProfile(string id)
+        [HttpGet("user/{id}/{filename}")]
+        public async Task<IActionResult> GetUserfile(string id, string filename)
         {
-            // Temp data
-            string path = "user_profile_2.local";
-            byte[] data = await System.IO.File.ReadAllBytesAsync(path);
-            return new FileContentResult(data, "application/octet-stream");
-        }
+			// get the user file from cloudstorage - any user can see files from another user
 
-        [HttpPut("{id}/user_profile_2")]
-        [Produces("application/octet-stream")]
-        public IActionResult UpdateProfile(string id)
-        {
-            return new NoContentResult();  
-        }
+			var file = await cloudstorageService.GetFileAsync(EpicID.FromString(id), filename);
+			if (file == null)
+			{
+				return Json(new ErrorResponse() { ErrorMessage = $"Sorry, we couldn't find a file {filename} for account {id}" }, 404);
+			}
 
-        // TODO: user_progression_1
-    }
+			return new FileContentResult(file.RawContent, "application/octet-stream");
+
+			//// Temp data
+			//string path = "user_profile_2.local";
+			//byte[] data = await System.IO.File.ReadAllBytesAsync(path);
+			//return new FileContentResult(data, "application/octet-stream");
+		}
+
+		[HttpPut("user/{id}/{filename}")]
+		public async Task<IActionResult> UpdateUserfile(string id, string filename)
+		{
+			await cloudstorageService.UpdateFileAsync(EpicID.FromString(id), filename, Request.Body);
+			return new NoContentResult();
+		}
+
+		[HttpGet("system")]
+		public Task<IActionResult> ListSystemfiles()
+		{
+			return ListUserfiles(EpicID.Empty.ToString());
+		}
+
+		[HttpGet("system/{filename}")]
+		public async Task<IActionResult> GetSystemfile(string filename)
+		{
+			return await GetUserfile(EpicID.Empty.ToString(), filename);
+		}
+	}
 }

--- a/UT4MasterServerDotNetCore/Controllers/JsonAPIController.cs
+++ b/UT4MasterServerDotNetCore/Controllers/JsonAPIController.cs
@@ -15,12 +15,14 @@ public class JsonAPIController : ControllerBase
 {
 	private static readonly string mimeJson = "application/json";
 
+	[NonAction]
 	public ContentResult Json(string content)
 	{
 		// i cant find a better way than to do this.
 		return Content(content, mimeJson);
 	}
 
+	[NonAction]
 	public ContentResult Json(string content, int status)
 	{
 		// i cant find a better way than to do this.
@@ -29,11 +31,13 @@ public class JsonAPIController : ControllerBase
 		return r;
 	}
 
+	[NonAction]
 	public ContentResult Json(JToken content)
 	{
 		return Json(content.ToString(Newtonsoft.Json.Formatting.None));
 	}
 
+	[NonAction]
 	public ContentResult Json(JToken content, int status)
 	{
 		var r = Json(content.ToString(Newtonsoft.Json.Formatting.None));
@@ -41,12 +45,14 @@ public class JsonAPIController : ControllerBase
 		return r;
 	}
 
+	[NonAction]
 	public ContentResult Json(JToken content, bool humanReadable)
 	{
 		var formatting = humanReadable ? Newtonsoft.Json.Formatting.Indented : Newtonsoft.Json.Formatting.None;
 		return Json(content.ToString(formatting));
 	}
 
+	[NonAction]
 	public ContentResult Json(JToken content, int status, bool humanReadable)
 	{
 		var formatting = humanReadable ? Newtonsoft.Json.Formatting.Indented : Newtonsoft.Json.Formatting.None;
@@ -55,11 +61,13 @@ public class JsonAPIController : ControllerBase
 		return r;
 	}
 
+	[NonAction]
 	public JsonResult Json(object? content)
 	{
 		return new JsonResult(content);
 	}
 
+	[NonAction]
 	public JsonResult Json(object? content, int status)
 	{
 		return new JsonResult(content) { StatusCode = status };

--- a/UT4MasterServerDotNetCore/Controllers/JsonAPIController.cs
+++ b/UT4MasterServerDotNetCore/Controllers/JsonAPIController.cs
@@ -21,9 +21,24 @@ public class JsonAPIController : ControllerBase
 		return Content(content, mimeJson);
 	}
 
+	public ContentResult Json(string content, int status)
+	{
+		// i cant find a better way than to do this.
+		var r = Content(content, mimeJson);
+		r.StatusCode = status;
+		return r;
+	}
+
 	public ContentResult Json(JToken content)
 	{
 		return Json(content.ToString(Newtonsoft.Json.Formatting.None));
+	}
+
+	public ContentResult Json(JToken content, int status)
+	{
+		var r = Json(content.ToString(Newtonsoft.Json.Formatting.None));
+		r.StatusCode = status;
+		return r;
 	}
 
 	public ContentResult Json(JToken content, bool humanReadable)
@@ -32,8 +47,21 @@ public class JsonAPIController : ControllerBase
 		return Json(content.ToString(formatting));
 	}
 
+	public ContentResult Json(JToken content, int status, bool humanReadable)
+	{
+		var formatting = humanReadable ? Newtonsoft.Json.Formatting.Indented : Newtonsoft.Json.Formatting.None;
+		var r = Json(content.ToString(formatting));
+		r.StatusCode = status;
+		return r;
+	}
+
 	public JsonResult Json(object? content)
 	{
 		return new JsonResult(content);
+	}
+
+	public JsonResult Json(object? content, int status)
+	{
+		return new JsonResult(content) { StatusCode = status };
 	}
 }

--- a/UT4MasterServerDotNetCore/Controllers/SessionController.cs
+++ b/UT4MasterServerDotNetCore/Controllers/SessionController.cs
@@ -211,6 +211,28 @@ public class SessionController : JsonAPIController
 	[Route("verify")]
 	public IActionResult Verify()
 	{
+		// no refresh needed, but we should respond with this:
+		/*
+		
+		{
+			"token": "06577db463064b89af0657b5445b08b7",
+			"session_id": "06577db463064b89af0657b5445b08b7",
+			"token_type": "bearer",
+			"client_id": "1252412dc7704a9690f6ea4611bc81ee",
+			"internal_client": false,
+			"client_service": "ut",
+			"account_id": "64bf8c6d81004e88823d577abe157373",
+			"expires_in": 28799,
+			"expires_at": "2022-12-20T23:26:25.049Z",
+			"auth_method": "exchange_code",
+			"display_name": "norandomemails",
+			"app": "ut",
+			"in_app_id": "64bf8c6d81004e88823d577abe157373",
+			"device_id": "ee64ee5f292b45f089a368cb7e43d82d",
+			"perms": [...]
+		}
+
+		*/
 		return new OkResult();
 	}
   

--- a/UT4MasterServerDotNetCore/Models/Account.cs
+++ b/UT4MasterServerDotNetCore/Models/Account.cs
@@ -80,7 +80,7 @@ public class Account
 	public int XPLastMatch { get; set; } = 0;
 
 	[BsonElement("XPLastMatchAt")]
-	public DateTime XPLastMatchAt { get; set; } = 0;
+	public DateTime XPLastMatchAt { get; set; } = DateTime.MinValue;
 
 
 	[BsonIgnore]

--- a/UT4MasterServerDotNetCore/Models/CloudFile.cs
+++ b/UT4MasterServerDotNetCore/Models/CloudFile.cs
@@ -1,0 +1,34 @@
+
+
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace UT4MasterServer.Models;
+
+[BsonNoId]
+public class CloudFile
+{
+	// ID = AccountID + Filename = unique key
+
+	[BsonElement("AccountID")]
+	public EpicID AccountID { get; set; } = EpicID.Empty; // EpicID.Empty is used for system files
+
+	[BsonElement("Filename")]
+	public string Filename { get; set; } = string.Empty;
+
+	[BsonElement("Hash")]
+	public string Hash { get; set; } = string.Empty; // TODO: figure out hash algo
+
+	[BsonElement("Hash256")]
+	public string Hash256 { get; set; } = string.Empty; // TODO: figure out hash algo
+
+	[BsonElement("UploadedAt")]
+	public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
+
+	[BsonElement("RawContent")]
+	[BsonRepresentation(MongoDB.Bson.BsonType.Binary)]
+	public byte[] RawContent { get; set; } = Array.Empty<byte>();
+
+	[BsonElement("Length")]
+	[BsonRepresentation(MongoDB.Bson.BsonType.Binary)]
+	public int Length { get; set; } = 0;
+}

--- a/UT4MasterServerDotNetCore/Models/UT4EverDatabaseSettings.cs
+++ b/UT4MasterServerDotNetCore/Models/UT4EverDatabaseSettings.cs
@@ -8,5 +8,6 @@ public class UT4EverDatabaseSettings
 	public string AccountCollectionName { get; set; } = string.Empty;
 	public string CodeCollectionName { get; set; } = string.Empty;
 	public string SessionCollectionName { get; set; } = string.Empty;
+	public string CloudstorageCollectionName { get; set; } = string.Empty;
 	public string AccountDataCollectionName { get; set; } = string.Empty;
 }

--- a/UT4MasterServerDotNetCore/Program.cs
+++ b/UT4MasterServerDotNetCore/Program.cs
@@ -56,6 +56,7 @@ public static partial class Program
 		builder.Services
 		  .AddSingleton<AccountService>()
 		  .AddSingleton<SessionService>()
+		  .AddSingleton<CloudstorageService>()
 		  .AddSingleton<AccountDataService>();	
 
 		builder.Services

--- a/UT4MasterServerDotNetCore/Services/AccountService.cs
+++ b/UT4MasterServerDotNetCore/Services/AccountService.cs
@@ -31,20 +31,29 @@ public class AccountService
 
 	public async Task<Account?> GetAccountAsync(EpicID id)
 	{
-		return await accountCollection.Find(account => account.ID == id).FirstOrDefaultAsync();
+		var cursor = await accountCollection.FindAsync(account => account.ID == id);
+		if (!await cursor.AnyAsync())
+			return null;
+		return await cursor.SingleOrDefaultAsync();
 	}
 
 	public async Task<Account?> GetAccountAsync(string username)
 	{
-		return await accountCollection.Find(account => account.Username == username).FirstOrDefaultAsync();
+		var cursor = await accountCollection.FindAsync(account => account.Username == username);
+		if (!await cursor.AnyAsync())
+			return null;
+		return await cursor.SingleOrDefaultAsync();
 	}
 
 	public async Task<Account?> GetAccountAsync(string username, string password)
 	{
-		return await accountCollection.Find(account =>
+		var cursor = await accountCollection.FindAsync(account =>
 			account.Username == username &&
 			account.Password == GetPasswordHash(password)
-		).FirstOrDefaultAsync();
+		);
+		if (!await cursor.AnyAsync())
+			return null;
+		return await cursor.SingleOrDefaultAsync();
 	}
 
 	public async Task<List<Account>> GetAccountsAsync(List<EpicID> ids)

--- a/UT4MasterServerDotNetCore/Services/CloudstorageService.cs
+++ b/UT4MasterServerDotNetCore/Services/CloudstorageService.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using UT4MasterServer.Models;
+using System.Text;
+using System.Security.Cryptography;
+
+namespace UT4MasterServer.Services;
+
+public class CloudstorageService
+{
+	// some general information about cloudstorage files
+	//
+	// systemfiles: <game_install_location>\UnrealTournament\PersistentDownloadDir\EMS
+	// system files are always downloaded when game boots
+	//
+	// userfiles: <documents>\UnrealTournament\Saved\Cloud\<accountID>\<filename>
+	// userfiles are only there while game is running and file had to have been needed within the game
+
+	private readonly IMongoCollection<CloudFile> cloudstorageCollection;
+
+	public CloudstorageService(IOptions<UT4EverDatabaseSettings> settings)
+	{
+		var mongoClient = new MongoClient(settings.Value.ConnectionString);
+		var mongoDatabase = mongoClient.GetDatabase(settings.Value.DatabaseName);
+		cloudstorageCollection = mongoDatabase.GetCollection<CloudFile>(settings.Value.CloudstorageCollectionName);
+	}
+
+	public async Task UpdateFileAsync(EpicID accountID, string filename, Stream dataStream)
+	{
+		// for now we only care about specific files
+		if (!IsCommonUserfileFilename(filename))
+			return;
+
+		byte[] buffer = new byte[1024 * 1024]; // 1MB = our max
+		int bytesRead = await dataStream.ReadAsync(buffer);
+		if (bytesRead < buffer.Length)
+		{
+			// if there have been fewer bytes read than buffer's length
+
+			// TODO: verify that Array.Resize works as expected and removes excess bytes from array
+			Array.Resize(ref buffer, bytesRead);
+
+			var file = new CloudFile()
+			{
+				AccountID = accountID,
+				Filename = filename,
+				Hash = CalcFileHash(buffer),
+				Hash256 = CalcFileHash256(buffer),
+				UploadedAt = DateTime.UtcNow,
+				RawContent = buffer,
+				Length = buffer.Length
+			};
+
+			// upsert = update or insert if doesn't exist
+			var options = new ReplaceOptions { IsUpsert = true };
+			await cloudstorageCollection.ReplaceOneAsync(
+				x => x.AccountID == accountID &&
+				x.Filename == filename, file, options
+			);
+		}
+	}
+
+	public async Task<CloudFile?> GetFileAsync(EpicID accountID, string filename)
+	{
+		var cursor = await cloudstorageCollection.FindAsync(
+			x => x.AccountID == accountID &&
+			x.Filename == filename
+		);
+		if (!await cursor.AnyAsync())
+			return null;
+		return await cursor.SingleOrDefaultAsync();
+	}
+
+	public async Task<List<CloudFile>> ListFilesAsync(EpicID accountID)
+	{
+		// TODO: make sure that CloudFile.Bytes remains empty after db retrieval
+		FindOptions<CloudFile> options = new FindOptions<CloudFile>()
+		{
+			Projection = Builders<CloudFile>.Projection.Exclude(x => x.RawContent)
+		};
+		var cursor = await cloudstorageCollection.FindAsync(x => x.AccountID == accountID, options);
+		return await cursor.ToListAsync();
+	}
+
+	public async Task DeleteFileAsync(EpicID accountID, string filename)
+	{
+		await cloudstorageCollection.DeleteOneAsync(
+			x => x.AccountID == accountID &&
+			x.Filename == filename
+		);
+	}
+
+
+
+	private static bool IsCommonUserfileFilename(string filename)
+	{
+		// old players might also have "user_profile_1", but it is not used for anything
+		return filename == "user_profile_2" || filename == "user_progression_1";
+	}
+
+	private static string CalcFileHash(byte[] data)
+	{
+		// TODO: figure out actual algo used, this one is pure guess
+		var hashedBytes = SHA1.HashData(data);
+		var hash = Convert.ToHexString(hashedBytes).ToLower();
+		return hash;
+	}
+
+	private static string CalcFileHash256(byte[] data)
+	{
+		// TODO: figure out actual algo used, this one is pure guess
+		var hashedBytes = SHA256.HashData(data);
+		var hash = Convert.ToHexString(hashedBytes).ToLower();
+		return hash;
+	}
+}

--- a/UT4MasterServerDotNetCore/appsettings.json
+++ b/UT4MasterServerDotNetCore/appsettings.json
@@ -6,7 +6,8 @@
 		"AccountCollectionName": "accounts",
 		"CodeCollectionName": "codes",
 		"SessionCollectionName": "sessions",
-		"AccountDataCollectionName":  "accountdata"
+		"CloudStorageCollectionName": "cloudstorage",
+		"AccountDataCollectionName": "accountdata"
 	},
 	"Logging":
 	{


### PR DESCRIPTION
# Description
This PR adds full cloudstorage support. db accepts only two files that everyone has: `user_progression_1` and `user_profile_2`. each file needs to be smaller than 1MB. mongodb supposedly has limit of 16MB, but since both of those files are way smaller i just limited their size to 1MB.

systemfiles need to be added to db before hand. they can be found at `<game_install_location>\UnrealTournament\PersistentDownloadDir\EMS`. systemfiles are identified in db with `AccountID == EpicID.Empty`,

# Missing work
There is one thing missing and that is to identify the correct hashing algorithms that epic uses when returning a list of files.