### PR TITLE
Add minimal support for listing pre-created list of hubs

### DIFF
--- a/UT4MasterServerDotNetCore/Controllers/JsonAPIController.cs
+++ b/UT4MasterServerDotNetCore/Controllers/JsonAPIController.cs
@@ -2,7 +2,9 @@
 
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Bson;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace UT4MasterServer.Controllers;
 
@@ -64,12 +66,12 @@ public class JsonAPIController : ControllerBase
 	[NonAction]
 	public JsonResult Json(object? content)
 	{
-		return new JsonResult(content);
+		return new JsonResult(content, new JsonSerializerOptions() { Converters = { new EpicIDJsonConverter() } });
 	}
 
 	[NonAction]
 	public JsonResult Json(object? content, int status)
 	{
-		return new JsonResult(content) { StatusCode = status };
+		return new JsonResult(content, new JsonSerializerOptions() { Converters = { new EpicIDJsonConverter() } }) { StatusCode = status };
 	}
 }

--- a/UT4MasterServerDotNetCore/Engine.ini
+++ b/UT4MasterServerDotNetCore/Engine.ini
@@ -36,3 +36,15 @@ Domain=ut4master.timiimit.com
 
 
 ; missing domain "datarouter.ol.epicgames.com". it seems that it is hardcoded and needs client modification to use.
+
+;
+; below are settings for an untested domain, which i have no clue what it does
+; but it is related to a feature that is in the game, but is missing from ut4's source code
+;
+
+[OnlineSubsystemMcp.OnlineContentControlsServiceMcp]
+Protocol=https
+;Domain=content-controls-prod.ol.epicgames.net
+Domain=ut4master.timiimit.com
+ServiceName=friends
+GameName=UnrealTournament

--- a/UT4MasterServerDotNetCore/EpicID.cs
+++ b/UT4MasterServerDotNetCore/EpicID.cs
@@ -63,7 +63,7 @@ public struct EpicID : IComparable<EpicID>, IEquatable<EpicID>, IConvertible, IB
 		if (obj == null)
 			return false;
 
-		if (obj is not UT4MasterServer.EpicID)
+		if (obj is not EpicID)
 			return false;
 
 		var objUserID = (EpicID)obj;
@@ -78,6 +78,8 @@ public struct EpicID : IComparable<EpicID>, IEquatable<EpicID>, IConvertible, IB
 
 	public override string ToString()
 	{
+		if (ID == null)
+			return Empty.ToString();
 		return ID;
 	}
 

--- a/UT4MasterServerDotNetCore/EpicIDJsonConverter.cs
+++ b/UT4MasterServerDotNetCore/EpicIDJsonConverter.cs
@@ -1,0 +1,52 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace UT4MasterServer;
+
+public class EpicIDJsonConverter : JsonConverter<EpicID>
+{
+	//public override bool CanWrite { get => true; }
+
+	//public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+	//{
+	//	if (value is EpicID eid)
+	//		writer.WriteToken(JsonToken.String, eid.ToString());
+	//}
+
+	//public override bool CanConvert(Type objectType)
+	//{
+	//	return objectType == typeof(string) || objectType == typeof(EpicID);
+	//}
+
+	//public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+	//{
+	//	if (reader.TokenType == JsonToken.String && objectType == typeof(EpicID))
+	//	{
+	//		if (reader.Value == null)
+	//			return EpicID.Empty;
+
+	//		var str = reader.Value as string;
+	//		if (str == null)
+	//			return EpicID.Empty;
+
+	//		return EpicID.FromString(str);
+	//	}
+
+	//	return null!;
+	//}
+
+
+	public override EpicID Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		var str = reader.GetString();
+		if (str == null)
+			return EpicID.Empty;
+
+		return EpicID.FromString(str);
+	}
+
+	public override void Write(Utf8JsonWriter writer, EpicID value, JsonSerializerOptions options)
+	{
+		writer.WriteStringValue(value.ToString());
+	}
+}

--- a/UT4MasterServerDotNetCore/GameServerJsonConverter.cs
+++ b/UT4MasterServerDotNetCore/GameServerJsonConverter.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+
+namespace UT4MasterServer;
+
+public class GameServerJsonConverter : JsonConverter
+{
+	public override bool CanWrite { get => false; }
+
+	public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+	{
+		throw new NotImplementedException();
+	}
+
+	public override bool CanConvert(Type objectType)
+	{
+		return objectType == typeof(GameServer) || objectType == typeof(string);
+	}
+
+	public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+	{
+		//if (reader.TokenType == JsonToken.String && objectType == typeof(GameServer))
+		//{
+		//	if (reader.Value == null)
+		//		return EpicID.Empty;
+
+		//	var str = reader.Value as GameServer;
+		//	if (str == null)
+		//		return EpicID.Empty;
+
+		//	return EpicID.FromString(str);
+		//}
+
+		return null!;
+	}
+}

--- a/UT4MasterServerDotNetCore/Models/GameServer.cs
+++ b/UT4MasterServerDotNetCore/Models/GameServer.cs
@@ -1,0 +1,276 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UT4MasterServer
+{
+	public enum GameServerTrust
+	{
+		Epic = 0,
+		Trusted = 1,
+		Untrusted = 2
+	}
+
+	public class GameServerAttributes
+	{
+		//// ordered from highest to lowest importance to end-user
+		//// commented properties seem to be always constant
+
+		//public string ServerName { get; set; }
+		//public string MatchCount { get; set; }
+		//public string MessageOfTheDay { get; set; }
+
+		//public string GameMode { get; set; }
+		//public string MapName { get; set; }
+		//public string MatchState { get; set; }
+		////public int MatchDuration { get; set; }
+
+		//public int PlayerCount { get; set; }
+		//public int MaxPlayers { get; set; }
+		//public int SpectatorCount { get; set; }
+		//public int MaxSpectators { get; set; }
+
+		//public ServerTrust TrustLevel { get; set; }
+		//public int ServerFlags { get; set; } // this seems to be either 0 or 1. i think i saw this in UT source. atm idk what it means
+		//public int MinELO { get; set; }
+		//public int MaxELO { get; set; }
+
+		//public string RedTeamSize { get; set; }
+		//public string BlueTeamSize { get; set; }
+
+		////public string ServerVersion { get; set; }
+		//public EpicID HubGUID { get; set; }
+		//public EpicID InstanceGUID { get; set; }
+		//public int BeaconPort { get; set; }
+		//public int GameInstance { get; set; }
+		////public bool TrainingGrounds { get; set; }
+
+		public Dictionary<string, object> ServerConfigs;
+
+		public GameServerAttributes()
+		{
+			ServerConfigs = new Dictionary<string, object>();
+		}
+
+		public void Add(string key, string value)
+		{
+			ServerConfigs.Add($"{key.ToUpper()}_s", value);
+		}
+
+		public void Add(string key, int value)
+		{
+			ServerConfigs.Add($"{key.ToUpper()}_i", value);
+		}
+
+		public void Add(string key, bool value)
+		{
+			ServerConfigs.Add($"{key.ToUpper()}_b", value);
+		}
+
+		public JObject ToJObject()
+		{
+			var obj = new JObject();
+
+			//obj.Add("UT_SERVERNAME_s", ServerName);
+			//obj.Add("UT_REDTEAMSIZE_i", RedTeamSize);
+			//obj.Add("UT_NUMMATCHES_i", MatchCount);
+			//obj.Add("UT_GAMEINSTANCE_i", GameInstance);
+			//obj.Add("UT_MAXSPECTATORS_i", MaxSpectators);
+			//obj.Add("BEACONPORT_i", BeaconPort);
+			//obj.Add("UT_PLAYERONLINE_i", PlayerCount);
+			//obj.Add("UT_SERVERVERSION_s", "3525360"); // version engraved into game's tombstone
+			//obj.Add("GAMEMODE_s", GameMode);
+			//obj.Add("UT_HUBGUID_s", HubGUID.ToString());
+			//obj.Add("UT_BLUETEAMSIZE_i", BlueTeamSize);
+			//obj.Add("UT_MATCHSTATE_s", MatchState);
+			//obj.Add("UT_SERVERTRUSTLEVEL_i", (int)TrustLevel);
+			//obj.Add("UT_SERVERINSTANCEGUID_s", InstanceGUID.ToString());
+			//obj.Add("UT_TRAININGGROUND_b", false);
+			//obj.Add("UT_MINELO_i", MinELO);
+			//obj.Add("UT_MAXELO_i", MaxELO);
+			//obj.Add("UT_SPECTATORSONLINE_i", SpectatorCount);
+			//obj.Add("UT_MAXPLAYERS_i", MaxPlayers);
+			//obj.Add("UT_SERVERMOTD_s", MessageOfTheDay);
+			//obj.Add("MAPNAME_s", MapName);
+			//obj.Add("UT_MATCHDURATION_i", 0);
+			//obj.Add("UT_SERVERFLAGS_i", ServerFlags);
+
+			foreach (var kvp in ServerConfigs)
+			{
+				if (kvp.Key.EndsWith("_b"))
+					obj.Add(kvp.Key, (bool)kvp.Value);
+				else if (kvp.Key.EndsWith("_i"))
+					obj.Add(kvp.Key, (int)kvp.Value);
+				else if (kvp.Key.EndsWith("_s"))
+					obj.Add(kvp.Key, (string)kvp.Value);
+			}
+
+			return obj;
+		}
+	}
+
+	public class GameServer
+	{
+		// commented properties seem to be always constant
+
+		public EpicID ID { get; set; }
+		public EpicID OwnerID { get; set; }
+		public string OwnerName { get; set; }
+		public string ServerName { get; set; }
+		public string ServerAddress { get; set; }
+		public int ServerPort { get; set; }
+		public int MaxPublicPlayers { get; set; }
+		public int OpenPublicPlayers { get; set; }
+		public int MaxPrivatePlayers { get; set; }
+		public int OpenPrivatePlayers { get; set; }
+		public GameServerAttributes Attributes { get; set; }
+		public List<EpicID> PublicPlayers { get; set; }
+		public List<EpicID> PrivatePlayers { get; set; }
+		public int TotalPlayers { get; set; }
+		public bool AllowJoinInProgress { get; set; }
+		public bool ShouldAdvertise { get; set; }
+		public bool IsDedicated { get; set; }
+		public bool UsesStats { get; set; }
+		public bool UsesPresence { get; set; }
+		public bool AllowInvites { get; set; }
+		public bool AllowJoinViaPresence { get; set; }
+		public bool AllowJoinViaPresenceFriendsOnly { get; set; }
+		public string BuildUniqueID { get; set; }
+		public DateTime LastUpdated { get; set; }
+		public int SortWeight { get; set; }
+		public bool Started { get; set; }
+
+		public GameServer()
+		{
+			ID = EpicID.GenerateNew();
+			OwnerID = EpicID.GenerateNew();
+			OwnerName = "[DS]nohost-00000";
+			ServerName = "[DS]nohost-00000";
+			ServerAddress = "0.0.0.0";
+			ServerPort = 7777;
+			MaxPublicPlayers = 10000;
+			OpenPublicPlayers = 10000;
+			MaxPrivatePlayers = 0;
+			OpenPrivatePlayers = 0;
+			Attributes = new GameServerAttributes();
+
+			Attributes.Add("UT_SERVERNAME", "ServerName");
+			Attributes.Add("UT_REDTEAMSIZE", 0);
+			Attributes.Add("UT_BLUETEAMSIZE", 0);
+			Attributes.Add("UT_NUMMATCHES", 0);
+			Attributes.Add("UT_GAMEINSTANCE", 0); // 0 = hub, 1 = game instance?
+			Attributes.Add("UT_MAXSPECTATORS", 7);
+			Attributes.Add("BEACONPORT", 7787);
+			Attributes.Add("UT_PLAYERONLINE", 0);
+			Attributes.Add("UT_SERVERVERSION", "3525360");
+			Attributes.Add("GAMEMODE", "/Script/UnrealTournament.UTLobbyGameMode");
+			Attributes.Add("UT_HUBGUID", OwnerID.ToString());
+			Attributes.Add("UT_MATCHSTATE", "InProgress");
+			Attributes.Add("UT_SERVERTRUSTLEVEL", 0);
+			Attributes.Add("UT_SERVERINSTANCEGUID", EpicID.GenerateNew().ToString());
+			Attributes.Add("UT_TRAININGGROUND", false);
+			Attributes.Add("UT_MINELO", 0);
+			Attributes.Add("UT_MAXELO", 0);
+			Attributes.Add("UT_SPECTATORSONLINE", 0);
+			Attributes.Add("UT_MAXPLAYERS", 200);
+			Attributes.Add("UT_SERVERMOTD", "");
+			Attributes.Add("MAPNAME", "UT-EntryRank");
+			Attributes.Add("UT_MATCHDURATION", 0);
+			Attributes.Add("UT_SERVERFLAGS", 0);
+
+			PublicPlayers = new List<EpicID>();
+			PrivatePlayers = new List<EpicID>();
+			TotalPlayers = 0;
+			AllowJoinInProgress = true;
+			ShouldAdvertise = true;
+			IsDedicated = true;
+			UsesStats = false;
+			AllowInvites = true;
+			UsesPresence = false;
+			AllowJoinViaPresence = true;
+			AllowJoinViaPresenceFriendsOnly = false;
+			BuildUniqueID = "256652735";
+			LastUpdated = DateTimeExtension.UnixTimestampStartOfTime;
+			Started = true;
+		}
+
+		/// <summary>
+		/// Temporary constructor to form fake servers for testing
+		/// </summary>
+		/// <param name=""></param>
+		internal GameServer(string serverName, string domain, string ipAddress) : this()
+		{
+			// it seems that at least ServerAddress is checked before game
+			// lists a hub
+			ServerName = OwnerName = domain;
+			ServerAddress = ipAddress;
+			Attributes.ServerConfigs["UT_SERVERNAME_s"] = serverName;
+		}
+
+
+		public void Heartbeat()
+		{
+			LastUpdated = DateTime.UtcNow;
+		}
+
+
+		public JObject ToJson(bool isResponseToClient)
+		{
+			//// these values seem to be constant
+			//int totalPlayers = PublicPlayers.Count + PrivatePlayers.Count;
+
+			//const int maxPublicPlayers = 10000;
+			//int maxOpenPublicPlayers = maxPublicPlayers - totalPlayers;
+			//const int maxPrivatePlayers = 0;
+			//const int maxOpenPrivatePlayers = 0;
+
+			// build json
+			var obj = new JObject();
+
+			obj.Add("id", ID.ToString());
+			obj.Add("ownerId", OwnerID.ToString());
+			obj.Add("ownerName", OwnerName);
+			obj.Add("serverName", ServerName);
+			obj.Add("serverAddress", ServerAddress);
+			obj.Add("serverPort", ServerPort);
+			obj.Add("maxPublicPlayers", MaxPublicPlayers);
+			obj.Add("openPublicPlayers", OpenPublicPlayers);
+			obj.Add("maxPrivatePlayers", MaxPrivatePlayers);
+			obj.Add("openPrivatePlayers", OpenPrivatePlayers);
+			obj.Add("attributes", Attributes.ToJObject());
+			JArray arr = new JArray();
+			foreach (var player in PublicPlayers)
+			{
+				arr.Add(player.ToString());
+			}
+			obj.Add("publicPlayers", arr);
+			arr = new JArray();
+			foreach (var player in PrivatePlayers)
+			{
+				arr.Add(player.ToString());
+			}
+			obj.Add("privatePlayers", arr);
+			obj.Add("totalPlayers", TotalPlayers);
+			obj.Add("allowJoinInProgress", AllowJoinInProgress);
+			obj.Add("shouldAdvertise", ShouldAdvertise);
+			obj.Add("isDedicated", IsDedicated);
+			obj.Add("usesStats", UsesStats);
+			obj.Add("allowInvites", AllowInvites);
+			obj.Add("usesPresence", UsesPresence);
+			obj.Add("allowJoinViaPresence", AllowJoinViaPresence);
+			obj.Add("allowJoinViaPresenceFriendsOnly", AllowJoinViaPresenceFriendsOnly);
+			obj.Add("buildUniqueId", BuildUniqueID);
+			obj.Add("lastUpdated", LastUpdated.ToStringISO());
+			obj.Add("started", Started);
+			if (!isResponseToClient)
+			{
+				obj.Add("sortWeights", SortWeight);
+			}
+
+			return obj;
+		}
+	}
+}

--- a/UT4MasterServerDotNetCore/Models/GameServerFilter.cs
+++ b/UT4MasterServerDotNetCore/Models/GameServerFilter.cs
@@ -1,0 +1,39 @@
+
+
+/*
+
+			{
+				"criteria": [
+					{
+						"type": "NOT_EQUAL",
+						"key": "UT_GAMEINSTANCE_i",
+						"value": 1
+					},
+					{
+						"type": "NOT_EQUAL",
+						"key": "UT_RANKED_i",
+						"value": 1
+					}
+				],
+				"buildUniqueId": "256652735",
+				"maxResults": 10000
+			}
+
+
+*/
+
+namespace UT4MasterServer.Models;
+
+public class GameServerAttributeCriteria
+{
+	public string Type { get; set; } = string.Empty;
+	public string Key { get; set; } = string.Empty;
+	public object? Value { get; set; } = null;
+}
+
+public class GameServerFilter
+{
+	public List<GameServerAttributeCriteria> Criteria { get; set; } = new List<GameServerAttributeCriteria>();
+	public string BuildUniqueId { get; set; } = string.Empty;
+	public int MaxResults { get; set; } = 0;
+}

--- a/UT4MasterServerDotNetCore/Program.cs
+++ b/UT4MasterServerDotNetCore/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson.Serialization;
+using Newtonsoft.Json.Linq;
 using System.Text.Encodings.Web;
 using UT4MasterServer.Authentication;
 using UT4MasterServer.Controllers;
@@ -9,7 +11,7 @@ using UT4MasterServer.Services;
 
 namespace UT4MasterServer;
 
-public static partial class Program
+public static class Program
 {
 	public static void Main(string[] args)
 	{
@@ -30,9 +32,7 @@ public static partial class Program
 		  .AddSingleton<AccountService>()
 		  .AddSingleton<SessionService>()
 		  .AddSingleton<CloudstorageService>()
-		  .AddSingleton<UnrealTournamentGameController>()
-		  .AddSingleton<UnrealTournamentStatsController>()
-		  .AddSingleton<UnrealTournamentMatchmakingController>();
+		  .AddSingleton<MatchmakingService>();
 
 		builder.Services
 		  .AddAuthentication(/*by default there is no authentication*/)

--- a/UT4MasterServerDotNetCore/Services/MatchmakingService.cs
+++ b/UT4MasterServerDotNetCore/Services/MatchmakingService.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using UT4MasterServer.Models;
+using System.Text;
+using System.Security.Cryptography;
+
+namespace UT4MasterServer.Services;
+
+public class MatchmakingService
+{
+	private Dictionary<EpicID, GameServer> serversBySession;
+
+	public MatchmakingService(IOptions<UT4EverDatabaseSettings> settings)
+	{
+		serversBySession = new Dictionary<EpicID, GameServer>();
+	}
+
+	public bool Add(EpicID sessionID, GameServer server)
+	{
+		if (serversBySession.ContainsKey(sessionID))
+			return false;
+
+		serversBySession.Add(sessionID, server);
+		return true;
+	}
+
+	public bool Update(EpicID sessionID, GameServer server)
+	{
+		if (!serversBySession.ContainsKey(sessionID))
+			return false;
+
+		if (serversBySession[sessionID].ID != server.ID)
+			return false;
+
+		return true;
+	}
+
+	public bool Remove(EpicID sessionID, EpicID serverID)
+	{
+		if (Get(sessionID, serverID) == null)
+			return false;
+
+		serversBySession.Remove(sessionID);
+		return true;
+	}
+
+	public GameServer? Get(EpicID sessionID, EpicID serverID)
+	{
+		if (!serversBySession.TryGetValue(sessionID, out var server))
+			return null;
+
+		if (server.ID != serverID)
+			return null;
+
+		return server;
+	}
+
+	public List<GameServer> List(GameServerFilter filter)
+	{
+		// TODO
+
+		throw new NotImplementedException();
+
+		return serversBySession.Values.ToList();
+	}
+
+	public bool Heartbeat(EpicID sessionID, EpicID serverID)
+	{
+		var server = Get(sessionID, serverID);
+
+		if (server == null)
+			return false;
+
+		server.Heartbeat(); // TODO: this is a reference and not a copy right?
+		return true;
+	}
+}


### PR DESCRIPTION
This PR as a proof of concept implements hub model and displays a predetermined list of hubs in hub list.
A valid ip (v4?) address of an actual game server needs to be returned for client to show it.