### PR TITLE
Ignore paths for GH Action and `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,9 @@
 **/values.dev.yaml
 LICENSE
 README.md
+
+# Our rules
+
+**/.github
+OldReferenceCode/**
+Files/Engine.ini

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -2,7 +2,19 @@ name: Build Docker Image
 
 on:
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'OldReferenceCode/**'
+      - 'XMPP-ejabberd/**'
+      - 'OldReferenceCode/**'
+      - 'Files/Engine.ini'
   push:
+    paths-ignore:
+      - '*.md'
+      - 'OldReferenceCode/**'
+      - 'XMPP-ejabberd/**'
+      - 'OldReferenceCode/**'
+      - 'Files/Engine.ini'
 
 env:
   IMAGE_NAME: ut4masterserver


### PR DESCRIPTION
This prevents building Docker image for PR like this: https://github.com/timiimit/UT4MasterServer/pull/30
Also, the build context for Docker will be smaller