### PR TITLE
Add `container_name` to docker-compose, fix `mongo-express`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
   mongo-express:
     container_name: mongo-express
     image: mongo-express
+    restart: always
     environment:
       - ME_CONFIG_MONGODB_SERVER=mongo
       - ME_CONFIG_MONGODB_PORT=27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 
 services:
   ut4masterserver:
+    container_name: UT4MasterServer
     image: ${DOCKER_REGISTRY-}ut4masterserver
     build:
       context: .
@@ -10,6 +11,7 @@ services:
       - "80:80"
       - "443:443"
   mongo:
+    container_name: mongo
     image: mongo
     environment:
       - MONGO_INITDB_ROOT_USERNAME=devroot
@@ -18,6 +20,7 @@ services:
     ports:
       - "27015:27015"
   mongo-express:
+    container_name: mongo-express
     image: mongo-express
     environment:
       - ME_CONFIG_MONGODB_SERVER=mongo


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/905878/210061912-69caa5ea-1205-4196-881a-cfb4f5661e8b.png)

After:

![image](https://user-images.githubusercontent.com/905878/210061949-b1c97ec0-0330-42b2-a2a7-cda23648bf37.png)


Fixes mongo-express startup (`failed to connect to server [mongo:27017] on first connect`):

![image](https://user-images.githubusercontent.com/905878/210064044-1bfcc324-0d51-41d5-a96e-97a403ce5fed.png)
