### PR TITLE
Parsing request header

### DIFF
--- a/UT4MasterServer/Authentication/HttpAuthorization.cs
+++ b/UT4MasterServer/Authentication/HttpAuthorization.cs
@@ -7,8 +7,8 @@ public class HttpAuthorization
 	public string Type { get; set; } = string.Empty;
 	public string Value { get; set; } = string.Empty;
 
-	public bool IsBearer { get => Type == "bearer"; }
-	public bool IsBasic { get => Type == "basic"; }
+	public bool IsBearer { get => Type.ToLower() == "bearer"; }
+	public bool IsBasic { get => Type.ToLower() == "basic"; }
 
 	public HttpAuthorization(HttpListenerRequest request) : this(request.Headers["Authorization"])
 	{


### PR DESCRIPTION
    chore:  Make sure incoming request value is formatted correctly
    This is just a tiny quality of life improvement. I personally believe
    the server should be able to handle whether a client sends `BeArEr xxx`
    or `bearer xxx`

    This will also make it easier to send requests using postman or swagger