### PR TITLE
Statistics validation

### DIFF
--- a/UT4MasterServer/Models/Statistic.cs
+++ b/UT4MasterServer/Models/Statistic.cs
@@ -24,4 +24,10 @@ public sealed class Statistic : StatisticBase
 
 	[BsonElement("window")]
 	public StatisticWindow Window { get; set; } = StatisticWindow.Daily;
+
+	[BsonElement("flagged"), BsonIgnoreIfNull]
+	public bool? Flagged { get; set; }
+
+	[BsonElement("flaggedProperties"), BsonIgnoreIfNull]
+	public List<string>? FlaggedProperties { get; set; }
 }

--- a/UT4MasterServer/Models/Statistic.cs
+++ b/UT4MasterServer/Models/Statistic.cs
@@ -25,9 +25,6 @@ public sealed class Statistic : StatisticBase
 	[BsonElement("window")]
 	public StatisticWindow Window { get; set; } = StatisticWindow.Daily;
 
-	[BsonElement("flagged"), BsonIgnoreIfNull]
-	public bool? Flagged { get; set; }
-
 	[BsonElement("flaggedProperties"), BsonIgnoreIfNull]
-	public List<string>? FlaggedProperties { get; set; }
+	public List<string>? Flagged { get; set; }
 }

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -316,6 +316,330 @@ public class StatisticBase
 		TeamKills = statisticBase.TeamKills;
 	}
 
+	public List<string> Validate()
+	{
+		var flaggedFields = new List<string>();
+
+		var totalKills = new int?[]
+		{
+			ImpactHammerKills,
+			EnforcerKills,
+			BioRifleKills,
+			BioLauncherKills,
+			ShockBeamKills,
+			ShockCoreKills,
+			ShockComboKills,
+			LinkKills,
+			LinkBeamKills,
+			MinigunKills,
+			MinigunShardKills,
+			FlakShardKills,
+			FlakShellKills,
+			RocketKills,
+			SniperKills, // SniperHeadshotKills are already included in SniperKills
+			LightningRiflePrimaryKills,
+			LightningRifleSecondaryKills,
+			RedeemerKills,
+			InstagibKills,
+			TelefragKills
+		}.Sum();
+
+		#region Quick Look Validations
+
+		// Since this is added after match, this property should be only 1
+		if (MatchesPlayed.HasValue && MatchesPlayed.Value > 1)
+		{
+			flaggedFields.Add(nameof(MatchesPlayed));
+		}
+		// Since this is added after match, this property should be only 1
+		if (MatchesQuit.HasValue && MatchesQuit.Value > 1)
+		{
+			flaggedFields.Add(nameof(MatchesQuit));
+		}
+		// You shouldn't have both Wins and Losses value available at the same time
+		if (MatchesPlayed.HasValue && MatchesQuit.HasValue && MatchesPlayed.Value > 0 && MatchesQuit.Value > 0)
+		{
+			flaggedFields.Add(nameof(MatchesPlayed));
+			flaggedFields.Add(nameof(MatchesQuit));
+		}
+		// Since this is added after match, this property should be only 1
+		if (Wins.HasValue && Wins.Value > 1)
+		{
+			flaggedFields.Add(nameof(Wins));
+		}
+		// Since this is added after match, this property should be only 1
+		if (Losses.HasValue && Losses.Value > 1)
+		{
+			flaggedFields.Add(nameof(Losses));
+		}
+		// You shouldn't have both Wins and Losses value available at the same time
+		if (Wins.HasValue && Losses.HasValue && Wins.Value > 0 && Losses.Value > 0)
+		{
+			flaggedFields.Add(nameof(Wins));
+			flaggedFields.Add(nameof(Losses));
+		}
+		// Maximum time for custom game is 60 minutes (1 minute is added just to be sure)
+		if (TimePlayed.HasValue && TimePlayed.Value > (60 * 60) + 60)
+		{
+			flaggedFields.Add(nameof(TimePlayed));
+		}
+		if (Kills.HasValue)
+		{
+			// Kills are reported if you manage to achieve 1 kill each 5 seconds
+			if (TimePlayed.HasValue && Kills.Value > (TimePlayed.Value / 5))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(TimePlayed));
+			}
+			// Kills are reported if they don't match the sum of individual weapon kills
+			if (Kills.Value != totalKills.Value)
+			{
+				flaggedFields.Add(nameof(Kills));
+			}
+		}
+		// Deaths are reported if you manage to achieve 1 death each 5 seconds
+		if (Deaths.HasValue && TimePlayed.HasValue && Deaths.Value > (TimePlayed.Value / 5))
+		{
+			flaggedFields.Add(nameof(Deaths));
+		}
+		// Suicides are reported if you manage to achieve 1 suicide each 5 seconds
+		if (Suicides.HasValue && TimePlayed.HasValue && Suicides.Value > (TimePlayed.Value / 5))
+		{
+			flaggedFields.Add(nameof(Suicides));
+		}
+
+		#endregion
+
+		#region Kill Achievements Validations
+
+		// Cannot have double kills without or more than actual kills                                                                   
+		if (MultiKillLevel0.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel0.Value * 2 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(MultiKillLevel0));
+			}
+		}
+		// Cannot have multi kills without or more than actual kills
+		if (MultiKillLevel1.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel1.Value * 3 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(MultiKillLevel1));
+			}
+		}
+		// Cannot have ultra kills without or more than actual kills
+		if (MultiKillLevel2.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel2.Value * 4 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(MultiKillLevel2));
+			}
+		}
+		// Cannot have monster kills without or more than actual kills
+		if (MultiKillLevel3.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel3.Value * 5 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(MultiKillLevel3));
+			}
+		}
+		// Cannot have killing spree without or more than actual kills
+		if (SpreeKillLevel0.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel0.Value * 5 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(SpreeKillLevel0));
+			}
+		}
+		// Cannot have rampages without or more than actual kills
+		if (SpreeKillLevel1.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel1.Value * 10 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(SpreeKillLevel1));
+			}
+		}
+		// Cannot have dominatings without or more than actual kills
+		if (SpreeKillLevel2.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel2.Value * 15 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(SpreeKillLevel2));
+			}
+		}
+		// Cannot have unstoppables without or more than actual kills
+		if (SpreeKillLevel3.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel3.Value * 20 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(SpreeKillLevel3));
+			}
+		}
+		// Cannot have godlikes without or more than actual kills
+		if (SpreeKillLevel4.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel4.Value * 25 < Kills.Value))
+			{
+				flaggedFields.Add(nameof(Kills));
+				flaggedFields.Add(nameof(SpreeKillLevel4));
+			}
+		}
+
+		#endregion
+
+		#region Power Up Achievements Validations
+
+		if (UDamageTime.HasValue)
+		{
+			// UDamage time cannot be longer than match time
+			if (TimePlayed.HasValue && UDamageTime.Value > TimePlayed.Value)
+			{
+				flaggedFields.Add(nameof(TimePlayed));
+				flaggedFields.Add(nameof(UDamageTime));
+			}
+		}
+		if (BerserkTime.HasValue)
+		{
+			// BerserkTime time cannot be longer than match time
+			if (TimePlayed.HasValue && BerserkTime.Value > TimePlayed.Value)
+			{
+				flaggedFields.Add(nameof(TimePlayed));
+				flaggedFields.Add(nameof(BerserkTime));
+			}
+		}
+		if (InvisibilityTime.HasValue)
+		{
+			// InvisibilityTime time cannot be longer than match time
+			if (TimePlayed.HasValue && InvisibilityTime.Value > TimePlayed.Value)
+			{
+				flaggedFields.Add(nameof(TimePlayed));
+				flaggedFields.Add(nameof(InvisibilityTime));
+			}
+		}
+
+		#endregion
+
+		#region Weapon Stats Validations
+
+		// Impact Hammer kills are reported if they are more than the actual kills
+		if (ImpactHammerKills.HasValue && Kills.HasValue && ImpactHammerKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(ImpactHammerKills));
+		}
+		// Enforcer kills are reported if they are more than the actual kills
+		if (EnforcerKills.HasValue && Kills.HasValue && EnforcerKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(EnforcerKills));
+		}
+		// Bio Rifle kills are reported if they are more than the actual kills
+		if (BioRifleKills.HasValue && Kills.HasValue && BioRifleKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(BioRifleKills));
+		}
+		// Grenade Launcher kills are reported if they are more than the actual kills
+		if (BioLauncherKills.HasValue && Kills.HasValue && BioLauncherKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(BioLauncherKills));
+		}
+		// Shock Beam kills are reported if they are more than the actual kills
+		if (ShockBeamKills.HasValue && Kills.HasValue && ShockBeamKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(ShockBeamKills));
+		}
+		// Shock Core kills are reported if they are more than the actual kills
+		if (ShockCoreKills.HasValue && Kills.HasValue && ShockCoreKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(ShockCoreKills));
+		}
+		// Shock Combo kills are reported if they are more than the actual kills
+		if (ShockComboKills.HasValue && Kills.HasValue && ShockComboKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(ShockComboKills));
+		}
+		// Link kills are reported if they are more than the actual kills
+		if (LinkKills.HasValue && Kills.HasValue && LinkKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(LinkKills));
+		}
+		// Link Beam kills are reported if they are more than the actual kills
+		if (LinkBeamKills.HasValue && Kills.HasValue && LinkBeamKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(LinkBeamKills));
+		}
+		// Minigun kills are reported if they are more than the actual kills
+		if (MinigunKills.HasValue && Kills.HasValue && MinigunKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(MinigunKills));
+		}
+		// Minigun Shard kills are reported if they are more than the actual kills
+		if (MinigunShardKills.HasValue && Kills.HasValue && MinigunShardKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(MinigunShardKills));
+		}
+		// Flak Shard kills are reported if they are more than the actual kills
+		if (FlakShardKills.HasValue && Kills.HasValue && FlakShardKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(FlakShardKills));
+		}
+		// Flak Shell kills are reported if they are more than the actual kills
+		if (FlakShellKills.HasValue && Kills.HasValue && FlakShellKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(FlakShellKills));
+		}
+		// Rocket kills are reported if they are more than the actual kills
+		if (RocketKills.HasValue && Kills.HasValue && RocketKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(RocketKills));
+		}
+		// Sniper kills are reported if they are more than the actual kills
+		if (SniperKills.HasValue && Kills.HasValue && SniperKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(SniperKills));
+		}
+		// Sniper Headshot kills are reported if they are more than the actual kills
+		if (SniperHeadshotKills.HasValue && Kills.HasValue && SniperHeadshotKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(SniperHeadshotKills));
+		}
+		// Lightning Rifle Primary kills are reported if they are more than the actual kills
+		if (LightningRiflePrimaryKills.HasValue && Kills.HasValue && LightningRiflePrimaryKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(LightningRiflePrimaryKills));
+		}
+		// Lightning Rifle Secondary kills are reported if they are more than the actual kills
+		if (LightningRifleSecondaryKills.HasValue && Kills.HasValue && LightningRifleSecondaryKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(LightningRifleSecondaryKills));
+		}
+		// Redeemer kills are reported if they are more than the actual kills
+		if (RedeemerKills.HasValue && Kills.HasValue && RedeemerKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(RedeemerKills));
+		}
+		// Instagib kills are reported if they are more than the actual kills
+		if (InstagibKills.HasValue && Kills.HasValue && InstagibKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(InstagibKills));
+		}
+		// Telefrag kills are reported if they are more than the actual kills
+		if (TelefragKills.HasValue && Kills.HasValue && TelefragKills.Value > Kills.Value)
+		{
+			flaggedFields.Add(nameof(TelefragKills));
+		}
+
+		#endregion
+
+		return flaggedFields;
+	}
+
 	#region Quick Look
 	[BsonElement("skillRating"), BsonIgnoreIfNull]
 	public int? SkillRating { get; set; }

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -342,7 +342,7 @@ public class StatisticBase
 			RedeemerKills,
 			InstagibKills,
 			TelefragKills
-		}.Sum();
+		}.Sum() ?? 0;
 
 		#region Quick Look Validations
 
@@ -392,7 +392,7 @@ public class StatisticBase
 				flaggedFields.Add(nameof(TimePlayed));
 			}
 			// Kills are reported if they don't match the sum of individual weapon kills
-			if (Kills.Value != totalKills.Value)
+			if (Kills.Value != totalKills)
 			{
 				flaggedFields.Add(nameof(Kills));
 			}

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -242,8 +242,7 @@ public sealed class StatisticsService
 		var flags = statisticBase.Validate();
 		if (flags.Any())
 		{
-			newStatistic.Flagged = true;
-			newStatistic.FlaggedProperties = flags;
+			newStatistic.Flagged = flags;
 		}
 
 		await statisticsCollection.InsertOneAsync(newStatistic);

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -295,26 +295,29 @@ public sealed class StatisticsService
 	{
 		var result = new List<StatisticDTO>();
 
-		foreach (var element in statisticBase.ToBsonDocument().Elements)
+		if (statisticBase is not null)
 		{
-			if (!StatisticBase.StatisticProperties.Contains(element.Name.ToLower())) continue;
-
-			var value = element.Value.BsonType switch
+			foreach (var element in statisticBase.ToBsonDocument().Elements)
 			{
-				BsonType.Double => (long)(element.Value.ToDouble() * 100D),
-				BsonType.Int32 => element.Value.ToInt32(),
-				_ => 0,
-			};
+				if (!StatisticBase.StatisticProperties.Contains(element.Name.ToLower())) continue;
 
-			if (value > 0)
-			{
-				result.Add(new StatisticDTO()
+				var value = element.Value.BsonType switch
 				{
-					Name = element.Name,
-					Value = value,
-					Window = statisticWindow.ToString().ToLower(),
-					OwnerType = OwnerType.Default
-				});
+					BsonType.Double => (long)(element.Value.ToDouble() * 100D),
+					BsonType.Int32 => element.Value.ToInt32(),
+					_ => 0,
+				};
+
+				if (value > 0)
+				{
+					result.Add(new StatisticDTO()
+					{
+						Name = element.Name,
+						Value = value,
+						Window = statisticWindow.ToString().ToLower(),
+						OwnerType = OwnerType.Default
+					});
+				}
 			}
 		}
 

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -239,6 +239,13 @@ public sealed class StatisticsService
 			Window = StatisticWindow.Daily,
 		};
 
+		var flags = statisticBase.Validate();
+		if (flags.Any())
+		{
+			newStatistic.Flagged = true;
+			newStatistic.FlaggedProperties = flags;
+		}
+
 		await statisticsCollection.InsertOneAsync(newStatistic);
 		await UpdateAllTimeAccountStatisticsAsync(newStatistic);
 	}


### PR DESCRIPTION
This is an initial implementation of statistics validation. When a suspicious value is posted as a statistic, that daily record of statistic will be flagged and the list of suspicious properties will be inserted with it for further analysis. Flagged statistics are still included in the daily/weekly/monthly/all-time statistics.

Additional rules and calculations should be added if needed, but they all require further in-game testing.

Related: [#22](https://github.com/timiimit/UT4MasterServer/issues/22)