### PR TITLE
Various front end bug fixes

### DIFF
--- a/UT4MasterServer.Web/src/components/LoadingPanel.vue
+++ b/UT4MasterServer.Web/src/components/LoadingPanel.vue
@@ -4,13 +4,12 @@
       <div class="spinner" />
     </div>
     <div class="content">
-      &nbsp;
       <slot />
     </div>
     <div class="alert alert-dismissible alert-danger" v-show="asyncStatus === AsyncStatus.ERROR">
       <button type="button" class="btn-close" @click="dismissError"></button>
-      <slot name="error" />
-      <div v-if="!$slots.error">An error occurred. Please try again.</div>
+      <div v-if="error">{{ error }}</div>
+      <div v-else>An error occurred. Please try again.</div>
     </div>
   </div>
 </template>
@@ -46,7 +45,8 @@ import { PropType, ref, watch, onUnmounted } from 'vue';
 import { AsyncStatus } from '../types/async-status';
 
 const props = defineProps({
-  status: Number as PropType<AsyncStatus>
+  status: Number as PropType<AsyncStatus>,
+  error: String
 })
 
 const asyncStatus = ref(props.status);

--- a/UT4MasterServer.Web/src/pages/Login.vue
+++ b/UT4MasterServer.Web/src/pages/Login.vue
@@ -1,44 +1,40 @@
 <template>
-  <LoadingPanel :status="status">
-    <template #default>
-      <form @submit.prevent="logIn">
-        <fieldset>
-          <legend>Log In</legend>
-          <div class="form-group row">
-            <label for="username" class="col-sm-12 col-form-label">Username</label>
-            <div class="col-sm-6">
-              <input type="text" class="form-control" id="username" name="username" required v-model="username"
-                placeholder="Username" autocomplete="username" />
-              <div class="invalid-feedback">Username is required</div>
-            </div>
-            <div class="col-sm-6 flex-v-center">
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" value="" id="saveUsername" v-model="saveUsername">
-                <label class="form-check-label" for="saveUsername">
-                  Save Username
-                </label>
-              </div>
+  <LoadingPanel :status="status" :error="errorMessage">
+    <form @submit.prevent="logIn">
+      <fieldset>
+        <legend>Log In</legend>
+        <div class="form-group row">
+          <label for="username" class="col-sm-12 col-form-label">Username</label>
+          <div class="col-sm-6">
+            <input type="text" class="form-control" id="username" name="username" required v-model="username"
+              placeholder="Username" autocomplete="username" autofocus />
+            <div class="invalid-feedback">Username is required</div>
+          </div>
+          <div class="col-sm-6 flex-v-center">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" value="" id="saveUsername" v-model="saveUsername"
+                tabindex="-1">
+              <label class="form-check-label" for="saveUsername">
+                Save Username
+              </label>
             </div>
           </div>
-          <div class="form-group row">
-            <label for="password" class="col-sm-12 col-form-label">Password</label>
-            <div class="col-sm-6">
-              <input type="password" class="form-control" id="password" name="password" minlength="7" v-model="password"
-                placeholder="Password" autocomplete="current-password" />
-              <div class="invalid-feedback">Password must be at least 7 characters</div>
-            </div>
+        </div>
+        <div class="form-group row">
+          <label for="password" class="col-sm-12 col-form-label">Password</label>
+          <div class="col-sm-6">
+            <input type="password" class="form-control" id="password" name="password" minlength="7" v-model="password"
+              placeholder="Password" autocomplete="current-password" />
+            <div class="invalid-feedback">Password must be at least 7 characters</div>
           </div>
-          <div class="form-group row">
-            <div class="col-sm-12">
-              <button type="submit" class="btn btn-primary" :disabled="!formValid">Log In</button>
-            </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-12">
+            <button type="submit" class="btn btn-primary" :disabled="!formValid" tabindex="2">Log In</button>
           </div>
-        </fieldset>
-      </form>
-    </template>
-    <template #error>
-      Error logging in. Please try again.
-    </template>
+        </div>
+      </fieldset>
+    </form>
   </LoadingPanel>
   <RouterLink to="/Register">Create an account</RouterLink>
 </template>
@@ -58,6 +54,7 @@ const password = shallowRef('');
 const saveUsername = shallowRef(SessionStore.saveUsername);
 const status = shallowRef(AsyncStatus.OK);
 const formValid = computed(() => username.value && password.value.length > 7);
+const errorMessage = shallowRef('Error logging in. Please try again.');
 
 const authenticationService = new AuthenticationService();
 
@@ -78,7 +75,7 @@ async function logIn() {
   }
   catch (err: unknown) {
     status.value = AsyncStatus.ERROR;
-    console.error(err);
+    errorMessage.value = (err as Error)?.message;
   }
 }
 </script>

--- a/UT4MasterServer.Web/src/pages/Profile/ChangeEmail.vue
+++ b/UT4MasterServer.Web/src/pages/Profile/ChangeEmail.vue
@@ -1,35 +1,31 @@
 <template>
-  <LoadingPanel :status="status">
-    <template #default>
-      <form :class="{ 'was-validated': submitAttempted }" @submit.prevent="handleSubmit" novalidate>
-        <fieldset>
-          <legend>Change Email</legend>
-          <div class="form-group row">
-            <label for="currentEmail" class="col-sm-12 col-form-label">Current Email</label>
-            <div class="col-sm-6">
-              <input type="email" class="form-control" id="currentEmail" name="currentEmail" v-model="currentEmail"
-                readonly disabled />
-            </div>
+  <LoadingPanel :status="status" :error="errorMessage">
+    <form :class="{ 'was-validated': submitAttempted }" @submit.prevent="handleSubmit" novalidate>
+      <fieldset>
+        <legend>Change Email</legend>
+        <div class="form-group row">
+          <label for="currentEmail" class="col-sm-12 col-form-label">Current Email</label>
+          <div class="col-sm-6">
+            <input type="email" class="form-control" id="currentEmail" name="currentEmail" v-model="currentEmail"
+              readonly disabled />
           </div>
-          <div class="form-group row">
-            <label for="newEmail" class="col-sm-12 col-form-label">New Email</label>
-            <div class="col-sm-6">
-              <input type="email" placeholder="player@example.com" class="form-control" id="newEmail" name="newEmail"
-                v-model="newEmail" required />
-              <div class="invalid-feedback">A valid email address is required</div>
-            </div>
+        </div>
+        <div class="form-group row">
+          <label for="newEmail" class="col-sm-12 col-form-label">New Email</label>
+          <div class="col-sm-6">
+            <input type="email" placeholder="player@example.com" class="form-control" id="newEmail" name="newEmail"
+              v-model="newEmail" required />
+            <div class="invalid-feedback">A valid email address is required</div>
           </div>
-          <div class="form-group row">
-            <div class="col-sm-12">
-              <button type="submit" class="btn btn-primary">Change Email</button>
-            </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-12">
+            <button type="submit" class="btn btn-primary">Change Email</button>
           </div>
-        </fieldset>
-      </form>
-    </template>
-    <template #error>
-      Error changing email. Please try again.
-    </template>
+        </div>
+      </fieldset>
+    </form>
+
   </LoadingPanel>
 </template>
 
@@ -51,6 +47,7 @@ const newEmail = shallowRef<string>('');
 const submitAttempted = shallowRef(false);
 
 const formValid = computed(() => newEmail.value?.length);
+const errorMessage = shallowRef('Error changing email. Please try again.');
 
 async function handleSubmit() {
   submitAttempted.value = true;
@@ -61,7 +58,6 @@ async function handleSubmit() {
     const request: IChangeEmailRequest = {
       newEmail: newEmail.value
     };
-    console.debug('Change username request', request);
     await accountService.changeEmail(request);
     status.value = AsyncStatus.OK;
     AccountStore.fetchUserAccount();
@@ -69,7 +65,7 @@ async function handleSubmit() {
   }
   catch (err: unknown) {
     status.value = AsyncStatus.ERROR;
-    console.error(err);
+    errorMessage.value = (err as Error)?.message;
   }
 }
 </script>

--- a/UT4MasterServer.Web/src/pages/Profile/ChangePassword.vue
+++ b/UT4MasterServer.Web/src/pages/Profile/ChangePassword.vue
@@ -1,47 +1,41 @@
 <template>
-
-  <LoadingPanel :status="status">
-    <template #default>
-      <form :class="{ 'was-validated': submitAttempted }" @submit.prevent="handleSubmit" novalidate>
-        <fieldset>
-          <legend>Change Password</legend>
-          <div class="form-group row">
-            <label for="currentPassword" class="col-sm-12 col-form-label">Current Password</label>
-            <div class="col-sm-6">
-              <input type="password" class="form-control" id="currentPassword" name="currentPassword" required
-                v-model="currentPassword" placeholder="Current Password" autocomplete="off" minlength="7" />
-              <div class="invalid-feedback">Current password must be at least 7 characters</div>
+  <LoadingPanel :status="status" :error="errorMessage">
+    <form :class="{ 'was-validated': submitAttempted }" @submit.prevent="handleSubmit" novalidate>
+      <fieldset>
+        <legend>Change Password</legend>
+        <div class="form-group row">
+          <label for="currentPassword" class="col-sm-12 col-form-label">Current Password</label>
+          <div class="col-sm-6">
+            <input type="password" class="form-control" id="currentPassword" name="currentPassword" required
+              v-model="currentPassword" placeholder="Current Password" autocomplete="off" minlength="7" />
+            <div class="invalid-feedback">Current password must be at least 7 characters</div>
+          </div>
+        </div>
+        <div class="form-group row">
+          <label for="newPassword" class="col-sm-12 col-form-label">New Password</label>
+          <div class="col-sm-6">
+            <input type="password" class="form-control" id="newPassword" name="newPassword" v-model="newPassword"
+              placeholder="New Password" autocomplete="off" required minlength="7" v-valid="newPasswordValid" />
+            <div v-if="!newPasswordLength" class="invalid-feedback">New Password must be at least 7 characters</div>
+            <div v-if="!newPasswordDiffers" class="invalid-feedback">New Password must differ from Current Password
             </div>
           </div>
-          <div class="form-group row">
-            <label for="newPassword" class="col-sm-12 col-form-label">New Password</label>
-            <div class="col-sm-6">
-              <input type="password" class="form-control" id="newPassword" name="newPassword" v-model="newPassword"
-                placeholder="New Password" autocomplete="off" required minlength="7" v-valid="newPasswordValid" />
-              <div v-if="!newPasswordLength" class="invalid-feedback">New Password must be at least 7 characters</div>
-              <div v-if="!newPasswordDiffers" class="invalid-feedback">New Password must differ from Current Password
-              </div>
-            </div>
+        </div>
+        <div class="form-group row">
+          <label for="confirmPassword" class="col-sm-12 col-form-label">Confirm Password</label>
+          <div class="col-sm-6">
+            <input type="password" class="form-control" v-model="confirmPassword" placeholder="Confirm Password"
+              autocomplete="off" required minlength="7" v-valid="confirmPasswordValid" />
+            <div v-if="!confirmPasswordValid" class="invalid-feedback">Confirm Password must match New Password</div>
           </div>
-          <div class="form-group row">
-            <label for="confirmPassword" class="col-sm-12 col-form-label">Confirm Password</label>
-            <div class="col-sm-6">
-              <input type="password" class="form-control" v-model="confirmPassword" placeholder="Confirm Password"
-                autocomplete="off" required minlength="7" v-valid="confirmPasswordValid" />
-              <div v-if="!confirmPasswordValid" class="invalid-feedback">Confirm Password must match New Password</div>
-            </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-12">
+            <button type="submit" class="btn btn-primary">Change Password</button>
           </div>
-          <div class="form-group row">
-            <div class="col-sm-12">
-              <button type="submit" class="btn btn-primary">Change Password</button>
-            </div>
-          </div>
-        </fieldset>
-      </form>
-    </template>
-    <template #error>
-      Error changing password. Please try again.
-    </template>
+        </div>
+      </fieldset>
+    </form>
   </LoadingPanel>
 </template>
 
@@ -71,6 +65,7 @@ const newPasswordDiffers = computed(() => newPassword.value !== currentPassword.
 const newPasswordValid = computed(() => newPasswordDiffers.value && newPasswordLength.value);
 const confirmPasswordValid = computed(() => confirmPassword.value === newPassword.value);
 const formValid = computed(() => currentPasswordValid.value && newPasswordValid.value && confirmPasswordValid.value);
+const errorMessage = shallowRef('Error changing email. Please try again.');
 
 async function handleSubmit() {
   submitAttempted.value = true;
@@ -84,14 +79,13 @@ async function handleSubmit() {
       currentPassword: CryptoJS.SHA512(currentPassword.value).toString(),
       newPassword: CryptoJS.SHA512(newPassword.value).toString()
     };
-    console.debug('Change password request', request);
     await accountService.changePassword(request);
     status.value = AsyncStatus.OK;
     router.push('/Profile');
   }
   catch (err: unknown) {
     status.value = AsyncStatus.ERROR;
-    console.error(err);
+    errorMessage.value = (err as Error)?.message;
   }
 }
 </script>

--- a/UT4MasterServer.Web/src/pages/Profile/ChangeUsername.vue
+++ b/UT4MasterServer.Web/src/pages/Profile/ChangeUsername.vue
@@ -1,35 +1,30 @@
 <template>
-  <LoadingPanel :status="status">
-    <template #default>
-      <form :class="{ 'was-validated': submitAttempted }" @submit.prevent="handleSubmit" novalidate>
-        <fieldset>
-          <legend>Change Username</legend>
-          <div class="form-group row">
-            <label for="currentUsername" class="col-sm-12 col-form-label">Current Username</label>
-            <div class="col-sm-6">
-              <input type="text" class="form-control" id="currentUsername" name="currentUsername"
-                v-model="currentUsername" readonly disabled />
-            </div>
+  <LoadingPanel :status="status" :error="errorMessage">
+    <form :class="{ 'was-validated': submitAttempted }" @submit.prevent="handleSubmit" novalidate>
+      <fieldset>
+        <legend>Change Username</legend>
+        <div class="form-group row">
+          <label for="currentUsername" class="col-sm-12 col-form-label">Current Username</label>
+          <div class="col-sm-6">
+            <input type="text" class="form-control" id="currentUsername" name="currentUsername"
+              v-model="currentUsername" readonly disabled />
           </div>
-          <div class="form-group row">
-            <label for="newUsername" class="col-sm-12 col-form-label">New Username</label>
-            <div class="col-sm-6">
-              <input type="text" class="form-control" id="newUsername" name="newUsername" placeholder="New Username"
-                v-model="newUsername" required />
-              <div class="invalid-feedback">New Username is required</div>
-            </div>
+        </div>
+        <div class="form-group row">
+          <label for="newUsername" class="col-sm-12 col-form-label">New Username</label>
+          <div class="col-sm-6">
+            <input type="text" class="form-control" id="newUsername" name="newUsername" placeholder="New Username"
+              v-model="newUsername" required />
+            <div class="invalid-feedback">New Username is required</div>
           </div>
-          <div class="form-group row">
-            <div class="col-sm-12">
-              <button type="submit" class="btn btn-primary">Change Username</button>
-            </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-12">
+            <button type="submit" class="btn btn-primary">Change Username</button>
           </div>
-        </fieldset>
-      </form>
-    </template>
-    <template #error>
-      Error changing username. Please try again.
-    </template>
+        </div>
+      </fieldset>
+    </form>
   </LoadingPanel>
 </template>
 
@@ -49,8 +44,8 @@ const status = shallowRef(AsyncStatus.OK);
 const currentUsername = shallowRef(AccountStore.account?.displayName);
 const newUsername = shallowRef<string>('');
 const submitAttempted = shallowRef(false);
-
 const formValid = computed(() => newUsername.value?.length);
+const errorMessage = shallowRef('Error changing email. Please try again.');
 
 async function handleSubmit() {
   submitAttempted.value = true;
@@ -60,7 +55,6 @@ async function handleSubmit() {
     const request: IChangeUsernameRequest = {
       newUsername: newUsername.value
     };
-    console.debug('Change username request', request);
     await accountService.changeUsername(request);
     status.value = AsyncStatus.OK;
     AccountStore.fetchUserAccount();
@@ -68,7 +62,7 @@ async function handleSubmit() {
   }
   catch (err: unknown) {
     status.value = AsyncStatus.ERROR;
-    console.error(err);
+    errorMessage.value = (err as Error)?.message;
   }
 }
 </script>

--- a/UT4MasterServer.Web/src/pages/Profile/PlayerCard.vue
+++ b/UT4MasterServer.Web/src/pages/Profile/PlayerCard.vue
@@ -1,0 +1,8 @@
+<template>
+  <h1>Player</h1>
+  <h3>Coming Soon!</h3>
+  <!-- 
+    Placeholder for the playerCard UI 
+  https://www.epicgames.com/unrealtournament/en-US/playerCard?playerId=0b0f09b400854b9b98932dd9e5abe7c5
+  -->
+</template>

--- a/UT4MasterServer.Web/src/pages/Register.vue
+++ b/UT4MasterServer.Web/src/pages/Register.vue
@@ -1,5 +1,5 @@
 <template>
-  <LoadingPanel :status="status">
+  <LoadingPanel :status="status" :error="errorMessage">
     <form @submit.prevent="register">
       <fieldset>
         <legend>Register</legend>
@@ -34,9 +34,6 @@
         </div>
       </fieldset>
     </form>
-    <template #error>
-      Error registering account. Please try again.
-    </template>
   </LoadingPanel>
 </template>
 
@@ -54,6 +51,7 @@ const password = shallowRef('');
 const email = shallowRef('');
 const status = shallowRef(AsyncStatus.OK);
 const formValid = computed(() => validateEmail(email.value) && username.value && password.value.length > 7 && status.value != AsyncStatus.BUSY);
+const errorMessage = shallowRef('Error registering account. Please try again.');
 
 const accountService = new AccountService();
 
@@ -72,7 +70,7 @@ async function register() {
     router.push('/Login');
   } catch (err: unknown) {
     status.value = AsyncStatus.ERROR;
-    console.error(err);
+    errorMessage.value = (err as Error)?.message;
   }
 }
 </script>

--- a/UT4MasterServer.Web/src/routes.ts
+++ b/UT4MasterServer.Web/src/routes.ts
@@ -12,16 +12,25 @@ export const routes: RouteRecordRaw[] = [
       import(
         './pages/Profile/Profile.vue'
       ),
+    // TODO: change to player card maybe?
     redirect: '/Profile/Stats',
     beforeEnter: privateGuard,
     children: [
+      {
+        path: `PlayerCard`,
+        component: async () =>
+          import(
+            './pages/Profile/PlayerCard.vue'
+          ),
+        beforeEnter: privateGuard
+      },
       {
         path: `ChangeUsername`,
         component: async () =>
           import(
             './pages/Profile/ChangeUsername.vue'
           ),
-          beforeEnter: privateGuard
+        beforeEnter: privateGuard
       },
       {
         path: `ChangePassword`,
@@ -29,7 +38,7 @@ export const routes: RouteRecordRaw[] = [
           import(
             './pages/Profile/ChangePassword.vue'
           ),
-          beforeEnter: privateGuard
+        beforeEnter: privateGuard
       },
       {
         path: `ChangeEmail`,
@@ -37,7 +46,7 @@ export const routes: RouteRecordRaw[] = [
           import(
             './pages/Profile/ChangeEmail.vue'
           ),
-          beforeEnter: privateGuard
+        beforeEnter: privateGuard
       },
       {
         path: `Stats`,
@@ -45,7 +54,7 @@ export const routes: RouteRecordRaw[] = [
           import(
             './pages/Stats.vue'
           ),
-          beforeEnter: privateGuard
+        beforeEnter: privateGuard
       }
     ]
   },
@@ -81,7 +90,7 @@ export const routes: RouteRecordRaw[] = [
       import(
         './pages/Register.vue'
       ),
-      beforeEnter: publicGuard
+    beforeEnter: publicGuard
   },
   {
     path: `/Login`,
@@ -89,7 +98,7 @@ export const routes: RouteRecordRaw[] = [
       import(
         './pages/Login.vue'
       ),
-      beforeEnter: publicGuard
+    beforeEnter: publicGuard
   },
   {
     path: `/`,

--- a/UT4MasterServer.Web/src/services/authentication.service.ts
+++ b/UT4MasterServer.Web/src/services/authentication.service.ts
@@ -1,7 +1,7 @@
 import { SessionStore as SessionStore } from '../stores/session-store';
 import { ILoginRequest } from '../types/login-request';
 import HttpService from './http.service';
-import { ISession } from '../types/session';
+import { ISession, IVerifySession } from '../types/session';
 import { GrantType } from '../enums/grant-type';
 import { IRefreshSessionRequest } from '../types/refresh-session-request';
 import { IAuthCodeResponse } from '../types/auth-code-response';
@@ -53,11 +53,14 @@ export default class AuthenticationService extends HttpService {
 
     async checkAuth() {
         try {
-            const session = await this.get<ISession>(`${this.baseUrl}/verify`);
-            // quick and dirty fix for the mismatch in the return object between /token and /verify
-            if (session.token) {
-                session.access_token = session.token;
-            }
+            const verifySession = await this.get<IVerifySession>(`${this.baseUrl}/verify`);
+            const session: ISession = { 
+                ...SessionStore.session!,
+                access_token: verifySession.token,
+                account_id: verifySession.account_id,
+                displayName: verifySession.display_name,
+                expires_at: verifySession.expires_at
+            };
             SessionStore.session = session;
         }
         catch (err: unknown) {

--- a/UT4MasterServer.Web/src/services/authentication.service.ts
+++ b/UT4MasterServer.Web/src/services/authentication.service.ts
@@ -54,6 +54,10 @@ export default class AuthenticationService extends HttpService {
     async checkAuth() {
         try {
             const session = await this.get<ISession>(`${this.baseUrl}/verify`);
+            // quick and dirty fix for the mismatch in the return object between /token and /verify
+            if (session.token) {
+                session.access_token = session.token;
+            }
             SessionStore.session = session;
         }
         catch (err: unknown) {

--- a/UT4MasterServer.Web/src/services/http.service.ts
+++ b/UT4MasterServer.Web/src/services/http.service.ts
@@ -35,7 +35,10 @@ export default class HttpService {
         const response = await fetch(url, fetchOptions);
 
         if (!response.ok) {
-            throw new Error(`HTTP request error - ${response.status}: ${response.statusText}`);
+            const error =  await response.json().catch(() => { });
+            const errorMessage = error.errorMessage ?? error;
+            const defaultErrorMessage = `HTTP request error - ${response.status}: ${response.statusText}`;
+            throw new Error(errorMessage ?? defaultErrorMessage);
         }
 
         const responseObj = await response.json().catch(() => { });

--- a/UT4MasterServer.Web/src/types/session.ts
+++ b/UT4MasterServer.Web/src/types/session.ts
@@ -5,6 +5,12 @@ export interface ISession {
     refresh_expires_at: string; //ISO date
     account_id: string;
     displayName: string;
-    token?: string;
-    session_id?: string;
+}
+
+export interface IVerifySession {
+    token: string;
+    session_id: string;
+    display_name: string;
+    expires_at: string; //ISO date
+    account_id: string;
 }

--- a/UT4MasterServer.Web/src/types/session.ts
+++ b/UT4MasterServer.Web/src/types/session.ts
@@ -5,4 +5,6 @@ export interface ISession {
     refresh_expires_at: string; //ISO date
     account_id: string;
     displayName: string;
+    token?: string;
+    session_id?: string;
 }

--- a/UT4MasterServer/Controllers/SessionController.cs
+++ b/UT4MasterServer/Controllers/SessionController.cs
@@ -379,7 +379,7 @@ public class SessionController : JsonAPIController
 
 		var obj = new JObject()
 		{
-			{ "token", user.AccessToken },
+			{ "access_token", user.AccessToken },
 			{ "session_id", user.Session.ID.ToString() },
 			{ "token_type", HttpAuthorization.BearerScheme.ToLower() },
 			{ "client_id", user.Session.ClientID.ToString() },

--- a/UT4MasterServer/Controllers/SessionController.cs
+++ b/UT4MasterServer/Controllers/SessionController.cs
@@ -379,7 +379,7 @@ public class SessionController : JsonAPIController
 
 		var obj = new JObject()
 		{
-			{ "access_token", user.AccessToken },
+			{ "token", user.AccessToken },
 			{ "session_id", user.Session.ID.ToString() },
 			{ "token_type", HttpAuthorization.BearerScheme.ToLower() },
 			{ "client_id", user.Session.ClientID.ToString() },


### PR DESCRIPTION
- Tabindex and autofocus in login page for easier entry
- Displaying error messages returned from server responses rather than default messages
- Verifying auth token by querying the verify endpoint rather than checking the expiry in localStorage. Failing this verification clears session from localStorage. Also, made logOut always clear session from localStorage so you can't get stuck logged in. At some point there should probably be a polling of the verify call added to automatically log a user out (or maybe automatically log out when any 401 is received from the API?), but as of now it happens on every page load.