### PR TITLE
EpicID error handling

### DIFF
--- a/UT4MasterServer/Controllers/ErrorsController.cs
+++ b/UT4MasterServer/Controllers/ErrorsController.cs
@@ -9,6 +9,12 @@ namespace UT4MasterServer.Controllers;
 [Route("api/errors")]
 public class ErrorsController : ControllerBase
 {
+	private readonly ILogger<ErrorsController> logger;
+	public ErrorsController(ILogger<ErrorsController> logger)
+	{
+		this.logger = logger;
+	}
+
 	[HttpGet]
 	public IActionResult Index()
 	{
@@ -16,10 +22,13 @@ public class ErrorsController : ControllerBase
 		var statusCode = 500;
 
 		var exceptionHandlerFeature = HttpContext.Features.Get<IExceptionHandlerPathFeature>();
+		var exception = exceptionHandlerFeature?.Error;
 
-		if (exceptionHandlerFeature?.Error is { } ex)
+		logger.LogError(exception, "Internal server error occurred.");
+
+		if (exception is not null)
 		{
-			switch (ex)
+			switch (exception)
 			{
 				case InvalidEpicIDException invalidEpicIDException:
 					return StatusCode(400, new ErrorResponse()

--- a/UT4MasterServer/Controllers/ErrorsController.cs
+++ b/UT4MasterServer/Controllers/ErrorsController.cs
@@ -9,7 +9,10 @@ namespace UT4MasterServer.Controllers;
 [Route("api/errors")]
 public class ErrorsController : ControllerBase
 {
+	private const string InternalServerError = "Internal server error occurred.";
+
 	private readonly ILogger<ErrorsController> logger;
+
 	public ErrorsController(ILogger<ErrorsController> logger)
 	{
 		this.logger = logger;
@@ -18,13 +21,13 @@ public class ErrorsController : ControllerBase
 	[HttpGet]
 	public IActionResult Index()
 	{
-		var message = "Internal server error occurred.";
+		var message = InternalServerError;
 		var statusCode = 500;
 
 		var exceptionHandlerFeature = HttpContext.Features.Get<IExceptionHandlerPathFeature>();
 		var exception = exceptionHandlerFeature?.Error;
 
-		logger.LogError(exception, "Internal server error occurred.");
+		logger.LogError(exception, InternalServerError);
 
 		if (exception is not null)
 		{

--- a/UT4MasterServer/Controllers/ErrorsController.cs
+++ b/UT4MasterServer/Controllers/ErrorsController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using UT4MasterServer.Exceptions;
+using UT4MasterServer.Models;
 
 namespace UT4MasterServer.Controllers;
 
@@ -20,10 +21,14 @@ public class ErrorsController : ControllerBase
 		{
 			switch (ex)
 			{
-				case InvalidEpicIDException:
-					message = ex.Message;
-					statusCode = 400;
-					break;
+				case InvalidEpicIDException invalidEpicIDException:
+					return StatusCode(400, new ErrorResponse()
+					{
+						ErrorCode = invalidEpicIDException.ErrorCode,
+						ErrorMessage = invalidEpicIDException.Message,
+						MessageVars = new string[] { invalidEpicIDException.ID },
+						NumericErrorCode = invalidEpicIDException.NumericErrorCode
+					});
 			}
 		}
 

--- a/UT4MasterServer/Controllers/UnrealTournamentStatsController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentStatsController.cs
@@ -28,8 +28,6 @@ public class UnrealTournamentStatsController : JsonAPIController
 	[HttpGet("accountId/{id}/bulk/window/daily")]
 	public async Task<IActionResult> GetDailyAccountStatistics(string id)
 	{
-		// TODO: Check id and return ErrorResponse if invalid: "Could not convert fakeAccountId to a UUID because it was not in a valid format: Invalid UUID string: fakeAccountId" (errors.com.epicgames.modules.stats.invalid_account_id)
-
 		var accountId = EpicID.FromString(id);
 		var result = await statisticsService.GetAggregateAccountStatisticsAsync(accountId, StatisticWindow.Daily);
 		return Ok(result);
@@ -40,8 +38,6 @@ public class UnrealTournamentStatsController : JsonAPIController
 	[HttpGet("accountId/{id}/bulk/window/weekly")]
 	public async Task<IActionResult> GetWeeklyAccountStatistics(string id)
 	{
-		// TODO: Check id and return ErrorResponse if invalid: "Could not convert fakeAccountId to a UUID because it was not in a valid format: Invalid UUID string: fakeAccountId" (errors.com.epicgames.modules.stats.invalid_account_id)
-
 		var accountId = EpicID.FromString(id);
 		var result = await statisticsService.GetAggregateAccountStatisticsAsync(accountId, StatisticWindow.Weekly);
 		return Ok(result);
@@ -52,8 +48,6 @@ public class UnrealTournamentStatsController : JsonAPIController
 	[HttpGet("accountId/{id}/bulk/window/monthly")]
 	public async Task<IActionResult> GetMonthlyAccountStatistics(string id)
 	{
-		// TODO: Check id and return ErrorResponse if invalid: "Could not convert fakeAccountId to a UUID because it was not in a valid format: Invalid UUID string: fakeAccountId" (errors.com.epicgames.modules.stats.invalid_account_id)
-
 		var accountId = EpicID.FromString(id);
 		var result = await statisticsService.GetAggregateAccountStatisticsAsync(accountId, StatisticWindow.Monthly);
 		return Ok(result);
@@ -64,8 +58,6 @@ public class UnrealTournamentStatsController : JsonAPIController
 	[HttpGet("accountId/{id}/bulk/window/alltime")]
 	public async Task<IActionResult> GetAllTimeAccountStatistics(string id)
 	{
-		// TODO: Check id and return ErrorResponse if invalid: "Could not convert fakeAccountId to a UUID because it was not in a valid format: Invalid UUID string: fakeAccountId" (errors.com.epicgames.modules.stats.invalid_account_id)
-
 		var accountId = EpicID.FromString(id);
 		var result = await statisticsService.GetAllTimeAccountStatisticsAsync(accountId);
 		return Ok(result);
@@ -79,8 +71,6 @@ public class UnrealTournamentStatsController : JsonAPIController
 		[FromQuery] OwnerType ownerType,
 		[FromBody] StatisticBase statisticBase)
 	{
-		// TODO: Check id and return ErrorResponse if invalid: "Could not convert fakeAccountId to a UUID because it was not in a valid format: Invalid UUID string: fakeAccountId" (errors.com.epicgames.modules.stats.invalid_account_id)
-
 		var accountId = EpicID.FromString(id);
 
 		if (User.Identity is not EpicUserIdentity user)

--- a/UT4MasterServer/Exceptions/InvalidEpicIDException.cs
+++ b/UT4MasterServer/Exceptions/InvalidEpicIDException.cs
@@ -5,26 +5,32 @@ namespace UT4MasterServer.Exceptions;
 [Serializable]
 public class InvalidEpicIDException : Exception
 {
+	private string _id { get; set; }
+	public string ID { get { return _id; } }
+
 	private int _numericErrorCode { get; set; }
 	public int NumericErrorCode { get { return _numericErrorCode; } }
 
 	private string _errorCode { get; set; }
 	public string ErrorCode { get { return _errorCode; } }
 
-	public InvalidEpicIDException(string message, int numericErrorCode, string errorCode) : base(message)
+	public InvalidEpicIDException(string message, string id, int numericErrorCode, string errorCode) : base(message)
 	{
+		_id = id;
 		_numericErrorCode = numericErrorCode;
 		_errorCode = errorCode;
 	}
 
-	public InvalidEpicIDException(string message, int numericErrorCode, string errorCode, Exception innerException) : base(message, innerException)
+	public InvalidEpicIDException(string message, string id, int numericErrorCode, string errorCode, Exception innerException) : base(message, innerException)
 	{
+		_id = id;
 		_numericErrorCode = numericErrorCode;
 		_errorCode = errorCode;
 	}
 
 	protected InvalidEpicIDException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
 	{
+		_id = serializationInfo.GetString(nameof(ID)) ?? string.Empty;
 		_numericErrorCode = serializationInfo.GetInt32(nameof(NumericErrorCode));
 		_errorCode = serializationInfo.GetString(nameof(ErrorCode)) ?? string.Empty;
 	}
@@ -36,6 +42,7 @@ public class InvalidEpicIDException : Exception
 			throw new ArgumentNullException(nameof(info));
 		}
 
+		info.AddValue(nameof(ID), ID);
 		info.AddValue(nameof(NumericErrorCode), NumericErrorCode);
 		info.AddValue(nameof(ErrorCode), ErrorCode);
 

--- a/UT4MasterServer/Exceptions/InvalidEpicIDException.cs
+++ b/UT4MasterServer/Exceptions/InvalidEpicIDException.cs
@@ -5,7 +5,40 @@ namespace UT4MasterServer.Exceptions;
 [Serializable]
 public class InvalidEpicIDException : Exception
 {
-	public InvalidEpicIDException(string message) : base(message) { }
+	private int _numericErrorCode { get; set; }
+	public int NumericErrorCode { get { return _numericErrorCode; } }
 
-	protected InvalidEpicIDException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
+	private string _errorCode { get; set; }
+	public string ErrorCode { get { return _errorCode; } }
+
+	public InvalidEpicIDException(string message, int numericErrorCode, string errorCode) : base(message)
+	{
+		_numericErrorCode = numericErrorCode;
+		_errorCode = errorCode;
+	}
+
+	public InvalidEpicIDException(string message, int numericErrorCode, string errorCode, Exception innerException) : base(message, innerException)
+	{
+		_numericErrorCode = numericErrorCode;
+		_errorCode = errorCode;
+	}
+
+	protected InvalidEpicIDException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
+	{
+		_numericErrorCode = serializationInfo.GetInt32(nameof(NumericErrorCode));
+		_errorCode = serializationInfo.GetString(nameof(ErrorCode)) ?? string.Empty;
+	}
+
+	public override void GetObjectData(SerializationInfo info, StreamingContext context)
+	{
+		if (info == null)
+		{
+			throw new ArgumentNullException(nameof(info));
+		}
+
+		info.AddValue(nameof(NumericErrorCode), NumericErrorCode);
+		info.AddValue(nameof(ErrorCode), ErrorCode);
+
+		base.GetObjectData(info, context);
+	}
 }

--- a/UT4MasterServer/Exceptions/InvalidEpicIDException.cs
+++ b/UT4MasterServer/Exceptions/InvalidEpicIDException.cs
@@ -5,34 +5,29 @@ namespace UT4MasterServer.Exceptions;
 [Serializable]
 public class InvalidEpicIDException : Exception
 {
-	private string _id { get; set; }
-	public string ID { get { return _id; } }
-
-	private int _numericErrorCode { get; set; }
-	public int NumericErrorCode { get { return _numericErrorCode; } }
-
-	private string _errorCode { get; set; }
-	public string ErrorCode { get { return _errorCode; } }
+	public string ID { get; private set; }
+	public int NumericErrorCode { get; private set; }
+	public string ErrorCode { get; private set; }
 
 	public InvalidEpicIDException(string message, string id, int numericErrorCode, string errorCode) : base(message)
 	{
-		_id = id;
-		_numericErrorCode = numericErrorCode;
-		_errorCode = errorCode;
+		ID = id;
+		NumericErrorCode = numericErrorCode;
+		ErrorCode = errorCode;
 	}
 
 	public InvalidEpicIDException(string message, string id, int numericErrorCode, string errorCode, Exception innerException) : base(message, innerException)
 	{
-		_id = id;
-		_numericErrorCode = numericErrorCode;
-		_errorCode = errorCode;
+		ID = id;
+		NumericErrorCode = numericErrorCode;
+		ErrorCode = errorCode;
 	}
 
 	protected InvalidEpicIDException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
 	{
-		_id = serializationInfo.GetString(nameof(ID)) ?? string.Empty;
-		_numericErrorCode = serializationInfo.GetInt32(nameof(NumericErrorCode));
-		_errorCode = serializationInfo.GetString(nameof(ErrorCode)) ?? string.Empty;
+		ID = serializationInfo.GetString(nameof(ID)) ?? string.Empty;
+		NumericErrorCode = serializationInfo.GetInt32(nameof(NumericErrorCode));
+		ErrorCode = serializationInfo.GetString(nameof(ErrorCode)) ?? string.Empty;
 	}
 
 	public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/UT4MasterServer/Other/EpicID.cs
+++ b/UT4MasterServer/Other/EpicID.cs
@@ -27,7 +27,7 @@ public struct EpicID : IComparable<EpicID>, IEquatable<EpicID>, IConvertible, IB
 	{
 		if (id.Length != 32)
 		{
-			throw new InvalidEpicIDException("ID needs to be 32 characters long.", id, 18009, "errors.com.epicgames.account.id_not_32_Characters");
+			throw new InvalidEpicIDException("ID needs to be 32 characters long.", id, 18009, "errors.com.epicgames.account.id_not_32_characters");
 		}
 
 		ID = id.ToLower();

--- a/UT4MasterServer/Other/EpicID.cs
+++ b/UT4MasterServer/Other/EpicID.cs
@@ -27,14 +27,14 @@ public struct EpicID : IComparable<EpicID>, IEquatable<EpicID>, IConvertible, IB
 	{
 		if (id.Length != 32)
 		{
-			throw new InvalidEpicIDException("ID needs to be 32 characters long.", id, 18009, "errors.com.epicgames.account.id_not_32_characters");
+			throw new InvalidEpicIDException("ID needs to be 32 characters long.", id, 18007, "errors.com.epicgames.modules.stats.invalid_account_id");
 		}
 
 		ID = id.ToLower();
 
 		if (!ID.IsHexString())
 		{
-			throw new InvalidEpicIDException("ID needs to be a hexadecimal string.", id, 18008, "errors.com.epicgames.account.id_not_hexadecimal");
+			throw new InvalidEpicIDException("ID needs to be a hexadecimal string.", id, 18007, "errors.com.epicgames.modules.stats.invalid_account_id");
 		}
 	}
 

--- a/UT4MasterServer/Other/EpicID.cs
+++ b/UT4MasterServer/Other/EpicID.cs
@@ -27,14 +27,14 @@ public struct EpicID : IComparable<EpicID>, IEquatable<EpicID>, IConvertible, IB
 	{
 		if (id.Length != 32)
 		{
-			throw new InvalidEpicIDException("ID needs to be 32 characters long.", 18009, "errors.com.epicgames.account.id_not_32_Characters");
+			throw new InvalidEpicIDException("ID needs to be 32 characters long.", id, 18009, "errors.com.epicgames.account.id_not_32_Characters");
 		}
 
 		ID = id.ToLower();
 
 		if (!ID.IsHexString())
 		{
-			throw new InvalidEpicIDException("ID needs to be a hexadecimal string.", 18008, "errors.com.epicgames.account.id_not_hexadecimal");
+			throw new InvalidEpicIDException("ID needs to be a hexadecimal string.", id, 18008, "errors.com.epicgames.account.id_not_hexadecimal");
 		}
 	}
 

--- a/UT4MasterServer/Other/EpicID.cs
+++ b/UT4MasterServer/Other/EpicID.cs
@@ -27,14 +27,14 @@ public struct EpicID : IComparable<EpicID>, IEquatable<EpicID>, IConvertible, IB
 	{
 		if (id.Length != 32)
 		{
-			throw new InvalidEpicIDException("ID needs to be 32 characters long.");
+			throw new InvalidEpicIDException("ID needs to be 32 characters long.", 18009, "errors.com.epicgames.account.id_not_32_Characters");
 		}
 
 		ID = id.ToLower();
 
 		if (!ID.IsHexString())
 		{
-			throw new InvalidEpicIDException("ID needs to be a hexadecimal string.");
+			throw new InvalidEpicIDException("ID needs to be a hexadecimal string.", 18008, "errors.com.epicgames.account.id_not_hexadecimal");
 		}
 	}
 


### PR DESCRIPTION
Returning `ErrorResponse `instead of only message when `InvalidEpicIDException `is thrown:

Examples:

`{
  "errorCode": "errors.com.epicgames.account.id_not_32_characters",
  "errorMessage": "ID needs to be 32 characters long.",
  "messageVars": [
    "9c808754479eaa36e7efe896f204da1"
  ],
  "numericErrorCode": 18009,
  "originatingService": null,
  "intent": null,
  "error_description": null,
  "error": null
}`

`{
  "errorCode": "errors.com.epicgames.account.id_not_hexadecimal",
  "errorMessage": "ID needs to be a hexadecimal string.",
  "messageVars": [
    "9c808754479eaa36e7efe896f204da1_"
  ],
  "numericErrorCode": 18008,
  "originatingService": null,
  "intent": null,
  "error_description": null,
  "error": null
}`

Related: [#22](https://github.com/timiimit/UT4MasterServer/issues/22)