### PR TITLE
Delete old statistic records

### DIFF
--- a/UT4MasterServer/Controllers/UnrealTournamentStatsController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentStatsController.cs
@@ -96,11 +96,4 @@ public class UnrealTournamentStatsController : JsonAPIController
 		await statisticsService.CreateAccountStatisticsAsync(accountId, ownerType, statisticBase);
 		return Ok();
 	}
-
-	[HttpDelete]
-	public async Task<IActionResult> DeleteOldStatistics(int days = 30, bool skipFlagged = true)
-	{
-		var result = await statisticsService.DeleteOldStatisticsAsync(days, skipFlagged);
-		return Ok(result);
-	}
 }

--- a/UT4MasterServer/Controllers/UnrealTournamentStatsController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentStatsController.cs
@@ -96,4 +96,11 @@ public class UnrealTournamentStatsController : JsonAPIController
 		await statisticsService.CreateAccountStatisticsAsync(accountId, ownerType, statisticBase);
 		return Ok();
 	}
+
+	[HttpDelete]
+	public async Task<IActionResult> DeleteOldStatistics(int days = 30, bool skipFlagged = true)
+	{
+		var result = await statisticsService.DeleteOldStatisticsAsync(days, skipFlagged);
+		return Ok(result);
+	}
 }

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -509,8 +509,9 @@ public sealed class StatisticsService
 
 		var removeBeforeDate = DateTime.UtcNow.Date.AddDays(-days);
 
-		var filter = Builders<Statistic>.Filter.Lt(f => f.CreatedAt, removeBeforeDate);
-		
+		var filter = Builders<Statistic>.Filter.Lt(f => f.CreatedAt, removeBeforeDate) &
+					 Builders<Statistic>.Filter.In(f => f.Window, new List<StatisticWindow>() { StatisticWindow.Daily });
+
 		if (skipFlagged)
 		{
 			filter &= Builders<Statistic>.Filter.Exists(f => f.Flagged, false);

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -513,7 +513,7 @@ public sealed class StatisticsService
 		
 		if (skipFlagged)
 		{
-			filter &= Builders<Statistic>.Filter.Eq(f => f.Flagged, null);
+			filter &= Builders<Statistic>.Filter.Exists(f => f.Flagged, false);
 		}
 
 		var result = await statisticsCollection.DeleteManyAsync(filter);

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -293,7 +293,7 @@ public sealed class StatisticsService
 	/// </summary>
 	/// <param name="statisticWindow"></param>
 	/// <returns></returns>
-	public static List<StatisticDTO> MapStatisticBaseToStatisticDTO(StatisticBase statisticBase, StatisticWindow statisticWindow)
+	private static List<StatisticDTO> MapStatisticBaseToStatisticDTO(StatisticBase statisticBase, StatisticWindow statisticWindow)
 	{
 		var result = new List<StatisticDTO>();
 


### PR DESCRIPTION
By default, this method is deleting statistics that are at least 30 days old and they don't have flagged properties. Currently, it can be only called from controller. When decided, we should put call to this method on specific places such as: after posting new statistics, after querying statistics, etc.

Related: [#22](https://github.com/timiimit/UT4MasterServer/issues/22)