### PR TITLE
Account and GameServer permissions

### DIFF
--- a/UT4MasterServer.Web/src/pages/Profile/PlayerCard.vue
+++ b/UT4MasterServer.Web/src/pages/Profile/PlayerCard.vue
@@ -10,7 +10,7 @@
         <tbody>
           <tr class="table-primary">
             <th scope="row">
-              <img class="avatar" :src="`/assets/avatars/${playerCard?.Avatar ?? 'UT.Avatar.1'}.png`" />
+              <img class="avatar" :src="`/assets/avatars/${playerCard?.Avatar ?? 'UT.Avatar.0'}.png`" />
               {{ playerCard?.Username }}
             </th>
             <td>

--- a/UT4MasterServer/Authentication/BasicAuthenticationHandler.cs
+++ b/UT4MasterServer/Authentication/BasicAuthenticationHandler.cs
@@ -32,12 +32,12 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 			}
 
 			var clientParser = new ClientIdentification(authorization.Value);
-			if (clientParser.ID.IsEmpty || clientParser.Secret.IsEmpty)
+			if (clientParser.ID.IsEmpty || string.IsNullOrEmpty(clientParser.Secret))
 			{
 				return AuthenticateResult.Fail("unexpected value in authorization header");
 			}
 
-			var client = await clientService.Get(clientParser.ID);
+			var client = await clientService.GetAsync(clientParser.ID);
 			if (client == null)
 			{
 				return AuthenticateResult.Fail("unknown client tried to authenticate");

--- a/UT4MasterServer/Authentication/BasicAuthenticationHandler.cs
+++ b/UT4MasterServer/Authentication/BasicAuthenticationHandler.cs
@@ -5,19 +5,24 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using UT4MasterServer.Services;
 
 namespace UT4MasterServer.Authentication;
 
 public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
+	private readonly ClientService clientService;
+
 	public BasicAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger,
-		UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
+		UrlEncoder encoder, ISystemClock clock,
+		ClientService clientService) : base(options, logger, encoder, clock)
 	{
+		this.clientService = clientService;
 	}
 
 	protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
 	{
-		return await Task.Run(() =>
+		return await Task.Run(async () =>
 		{
 			var authorizationHeader = Request.Headers[HttpAuthorization.AuthorizationHeader];
 			var authorization = new HttpAuthorization(authorizationHeader);
@@ -26,16 +31,25 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 				return AuthenticateResult.Fail("unexpected scheme");
 			}
 
-			var client = new ClientIdentification(authorization.Value);
-			if (client.ID.IsEmpty || client.Secret.IsEmpty)
+			var clientParser = new ClientIdentification(authorization.Value);
+			if (clientParser.ID.IsEmpty || clientParser.Secret.IsEmpty)
 			{
-				const string errMessage = "unexpected value in authorization header";
-				return AuthenticateResult.Fail(errMessage);
+				return AuthenticateResult.Fail("unexpected value in authorization header");
 			}
 
-			// TODO: we could verify that request is coming from a valid client.
-			//       that means either ClientIdentification.Game, ClientIdentification.Launcher
-			//       or a new (ID:Secret) pair created just for our website.
+			var client = await clientService.Get(clientParser.ID);
+			if (client == null)
+			{
+				return AuthenticateResult.Fail("unknown client tried to authenticate");
+			}
+			if (client.Secret != clientParser.Secret)
+			{
+				// TODO: since client login was invalid, it means that someone is trying to impersonate
+				//       this client or some human error is involved.
+				//
+				//       someone should be notified that this is happening!
+				return AuthenticateResult.Fail("client ID:Secret pair is invalid");
+			}
 
 			var principal = new ClaimsPrincipal(new EpicClientIdentity(client));
 			var ticket = new AuthenticationTicket(principal, Scheme.Name);

--- a/UT4MasterServer/Authentication/BasicAuthenticationHandler.cs
+++ b/UT4MasterServer/Authentication/BasicAuthenticationHandler.cs
@@ -30,7 +30,6 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 			if (client.ID.IsEmpty || client.Secret.IsEmpty)
 			{
 				const string errMessage = "unexpected value in authorization header";
-				Logger.LogInformation(errMessage);
 				return AuthenticateResult.Fail(errMessage);
 			}
 

--- a/UT4MasterServer/Authentication/BearerAuthenticationHandler.cs
+++ b/UT4MasterServer/Authentication/BearerAuthenticationHandler.cs
@@ -32,7 +32,6 @@ public class BearerAuthenticationHandler : AuthenticationHandler<AuthenticationS
 		if (session == null)
 		{
 			const string errMessage = "invalid token";
-			Logger.LogInformation(errMessage);
 			return AuthenticateResult.Fail(errMessage);
 		}
 

--- a/UT4MasterServer/Authentication/ClientIdentification.cs
+++ b/UT4MasterServer/Authentication/ClientIdentification.cs
@@ -8,21 +8,21 @@ public class ClientIdentification
 {
 	public static ClientIdentification Launcher = new ClientIdentification(
 		EpicID.FromString("34a02cf8f4414e29b15921876da36f9a"),
-		EpicID.FromString("daafbccc737745039dffe53d94fc76cf")
+		"daafbccc737745039dffe53d94fc76cf"
 	);
 	public static ClientIdentification Game = new ClientIdentification(
 		EpicID.FromString("1252412dc7704a9690f6ea4611bc81ee"),
-		EpicID.FromString("2ca0c925b4674852bff92b26f8322434")
+		"2ca0c925b4674852bff92b26f8322434"
 	);
 	public static ClientIdentification ServerInstance = new ClientIdentification(
 		EpicID.FromString("6ff43e743edc4d1dbac3594877b4bed9"),
-		EpicID.FromString("54619d6f84d443e195200b54ab649a53")
+		"54619d6f84d443e195200b54ab649a53"
 	);
 
 	//public static string GameAuthorization = "MTI1MjQxMmRjNzcwNGE5NjkwZjZlYTQ2MTFiYzgxZWU6MmNhMGM5MjViNDY3NDg1MmJmZjkyYjI2ZjgzMjI0MzQ=";
 
 	public EpicID ID { get; private set; }
-	public EpicID Secret { get; private set; }
+	public string Secret { get; private set; }
 	public string Authorization { get; private set; }
 
 	public ClientIdentification(string authorization)
@@ -35,7 +35,7 @@ public class ClientIdentification
 			{
 				Authorization = authorization;
 				ID = EpicID.FromString(decoded.Substring(0, colon));
-				Secret = EpicID.FromString(decoded.Substring(colon + 1));
+				Secret = decoded.Substring(colon + 1);
 				return;
 			}
 		}
@@ -43,10 +43,10 @@ public class ClientIdentification
 		// unknown format
 		Authorization = authorization;
 		ID = EpicID.Empty;
-		Secret = EpicID.Empty;
+		Secret = string.Empty;
 	}
 
-	public ClientIdentification(EpicID id, EpicID secret)
+	public ClientIdentification(EpicID id, string secret)
 	{
 		string auth = $"{id}:{secret}";
 		Authorization = Convert.ToBase64String(Encoding.UTF8.GetBytes(auth));

--- a/UT4MasterServer/Authentication/EpicClientIdentity.cs
+++ b/UT4MasterServer/Authentication/EpicClientIdentity.cs
@@ -1,12 +1,13 @@
 ﻿using System.Security.Claims;
+using UT4MasterServer.Models;
 
 namespace UT4MasterServer.Authentication;
 
 public class EpicClientIdentity : ClaimsIdentity
 {
-	public ClientIdentification Client { get; private set; }
+	public Client Client { get; private set; }
 
-	public EpicClientIdentity(ClientIdentification client) : base(HttpAuthorization.BasicScheme)
+	public EpicClientIdentity(Client client) : base(HttpAuthorization.BasicScheme)
 	{
 		Client = client;
 

--- a/UT4MasterServer/Controllers/UnrealTournamentMatchmakingController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentMatchmakingController.cs
@@ -24,7 +24,6 @@ public class UnrealTournamentMatchmakingController : JsonAPIController
 {
 	private readonly MatchmakingService matchmakingService;
 	private readonly TrustedGameServerService trustedGameServerService;
-	private readonly ClientService clientService;
 
 	private readonly IOptions<ApplicationSettings> configuration;
 	private const int MAX_READ_SIZE = 1024 * 4;
@@ -38,7 +37,6 @@ public class UnrealTournamentMatchmakingController : JsonAPIController
 	{
 		this.configuration = configuration;
 		this.matchmakingService = matchmakingService;
-		this.clientService = clientService;
 		this.trustedGameServerService = trustedGameServerService;
 	}
 

--- a/UT4MasterServer/Models/Account.cs
+++ b/UT4MasterServer/Models/Account.cs
@@ -101,7 +101,7 @@ public class Account
 	public DateTime LastMatchAt { get; set; } = DateTime.UnixEpoch;
 
 	[BsonIgnoreIfDefault, BsonDefaultValue(AccountFlags.None)]
-	public AccountFlags Flags { get; set; }
+	public AccountFlags Flags { get; set; } = AccountFlags.None;
 
 	[BsonIgnore]
 	public float Level

--- a/UT4MasterServer/Models/Account.cs
+++ b/UT4MasterServer/Models/Account.cs
@@ -4,6 +4,17 @@ using UT4MasterServer.Other;
 namespace UT4MasterServer.Models;
 using System.Text.Json.Serialization;
 
+[Flags]
+public enum AccountFlags
+{
+	None = 0,
+	Admin = 1,
+	Moderator = 2,
+	Developer = 4,
+	ContentCreator = 8,
+	HubOwner = 16
+}
+
 [BsonIgnoreExtraElements]
 public class Account
 {
@@ -88,6 +99,9 @@ public class Account
 	[BsonIgnoreIfDefault] // default value is set in Program.cs
 	[BsonElement("XPLastMatchAt")]
 	public DateTime LastMatchAt { get; set; } = DateTime.UnixEpoch;
+
+	[BsonIgnoreIfDefault, BsonDefaultValue(AccountFlags.None)]
+	public AccountFlags Flags { get; set; }
 
 	[BsonIgnore]
 	public float Level

--- a/UT4MasterServer/Models/Client.cs
+++ b/UT4MasterServer/Models/Client.cs
@@ -13,7 +13,7 @@ public class Client
 	public EpicID Secret { get; set; }
 
 	[BsonIgnoreIfNull]
-	[BsonElement("Secret")]
+	[BsonElement("Name")]
 	public string? Name { get; set; }
 
 	public Client(EpicID id, EpicID secret, string? name = null)

--- a/UT4MasterServer/Models/Client.cs
+++ b/UT4MasterServer/Models/Client.cs
@@ -1,0 +1,25 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using UT4MasterServer.Authentication;
+using UT4MasterServer.Other;
+
+namespace UT4MasterServer.Models;
+
+public class Client
+{
+	[BsonElement("ID"), BsonId]
+	public EpicID ID { get; set; }
+
+	[BsonElement("Secret")]
+	public EpicID Secret { get; set; }
+
+	[BsonIgnoreIfNull]
+	[BsonElement("Secret")]
+	public string? Name { get; set; }
+
+	public Client(EpicID id, EpicID secret, string? name = null)
+	{
+		ID = id;
+		Secret = secret;
+		Name = name;
+	}
+}

--- a/UT4MasterServer/Models/Client.cs
+++ b/UT4MasterServer/Models/Client.cs
@@ -10,13 +10,13 @@ public class Client
 	public EpicID ID { get; set; }
 
 	[BsonElement("Secret")]
-	public EpicID Secret { get; set; }
+	public string Secret { get; set; }
 
 	[BsonIgnoreIfNull]
 	[BsonElement("Name")]
 	public string? Name { get; set; }
 
-	public Client(EpicID id, EpicID secret, string? name = null)
+	public Client(EpicID id, string secret, string? name = null)
 	{
 		ID = id;
 		Secret = secret;

--- a/UT4MasterServer/Models/GameServer.cs
+++ b/UT4MasterServer/Models/GameServer.cs
@@ -108,8 +108,21 @@ public class GameServer
 	/// <summary>
 	/// GameServer's Session
 	/// </summary>
+	/// <remarks>
+	/// Each session is allowed to have only a single server
+	/// </remarks>
 	[BsonElement("SessionID")]
 	public EpicID SessionID { get; set; } = EpicID.Empty;
+
+	/// <summary>
+	/// GameServer's OwningClientID
+	/// </summary>
+	/// <remarks>
+	/// All game servers owned by a single entity (hub owner) have the same client ID
+	/// </remarks>
+	[BsonElement("OwningClientID")]
+	public EpicID OwningClientID { get; set; } = EpicID.Empty;
+
 
 #if DEBUG
 	[BsonElement("SessionAccessToken")]
@@ -263,6 +276,9 @@ public class GameServer
 
 	public void Update(GameServer update)
 	{
+		SessionID = update.SessionID;
+		OwningClientID = update.OwningClientID;
+
 		MaxPublicPlayers = update.MaxPublicPlayers;
 		MaxPrivatePlayers = update.MaxPrivatePlayers;
 		//OpenPublicPlayers = update.OpenPublicPlayers;

--- a/UT4MasterServer/Models/TrustedGameServer.cs
+++ b/UT4MasterServer/Models/TrustedGameServer.cs
@@ -9,9 +9,6 @@ public class TrustedGameServer
 	[BsonElement("ID"), BsonId]
 	public EpicID ID { get; set; }
 
-	[BsonElement("Secret")]
-	public EpicID Secret { get; set; }
-
 	[BsonElement("OwnerID")]
 	public EpicID OwnerID { get; set; }
 

--- a/UT4MasterServer/Models/TrustedGameServer.cs
+++ b/UT4MasterServer/Models/TrustedGameServer.cs
@@ -1,0 +1,21 @@
+using MongoDB.Bson.Serialization.Attributes;
+using UT4MasterServer.Authentication;
+using UT4MasterServer.Other;
+
+namespace UT4MasterServer.Models;
+
+public class TrustedGameServer
+{
+	[BsonElement("ID"), BsonId]
+	public EpicID ID { get; set; }
+
+	[BsonElement("Secret")]
+	public EpicID Secret { get; set; }
+
+	[BsonElement("OwnerID")]
+	public EpicID OwnerID { get; set; }
+
+	[BsonIgnoreIfDefault, BsonDefaultValue(GameServerTrust.Trusted)]
+	[BsonElement("TrustLevel")]
+	public GameServerTrust TrustLevel { get; set; } = GameServerTrust.Trusted;
+}

--- a/UT4MasterServer/Program.cs
+++ b/UT4MasterServer/Program.cs
@@ -83,9 +83,10 @@ public static class Program
 		// services whose instance is created per-request
 		builder.Services
 			.AddScoped<DatabaseContext>()
-			.AddScoped<FriendService>()
+			.AddScoped<ClientService>()
 			.AddScoped<AccountService>()
 			.AddScoped<SessionService>()
+			.AddScoped<FriendService>()
 			.AddScoped<CloudStorageService>()
 			.AddScoped<MatchmakingService>()
 			.AddScoped<StatisticsService>();

--- a/UT4MasterServer/Program.cs
+++ b/UT4MasterServer/Program.cs
@@ -88,6 +88,7 @@ public static class Program
 			.AddScoped<SessionService>()
 			.AddScoped<FriendService>()
 			.AddScoped<CloudStorageService>()
+			.AddScoped<TrustedGameServerService>()
 			.AddScoped<MatchmakingService>()
 			.AddScoped<StatisticsService>();
 

--- a/UT4MasterServer/Services/ApplicationStartupService.cs
+++ b/UT4MasterServer/Services/ApplicationStartupService.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
-using MongoDB.Driver;
+using UT4MasterServer.Authentication;
 using UT4MasterServer.Models;
 
 namespace UT4MasterServer.Services
@@ -9,6 +9,7 @@ namespace UT4MasterServer.Services
 		private readonly ILogger<ApplicationStartupService> logger;
 		private readonly StatisticsService statisticsService;
 		private readonly CloudStorageService cloudStorageService;
+		private readonly ClientService clientService;
 
 		public ApplicationStartupService(
 			ILogger<ApplicationStartupService> logger, ILogger<StatisticsService> statsLogger,
@@ -18,6 +19,7 @@ namespace UT4MasterServer.Services
 			var db = new DatabaseContext(settings);
 			statisticsService = new StatisticsService(statsLogger, db);
 			cloudStorageService = new CloudStorageService(db);
+			clientService = new ClientService(db);
 		}
 
 		public async Task StartAsync(CancellationToken cancellationToken)
@@ -25,8 +27,25 @@ namespace UT4MasterServer.Services
 			logger.LogInformation("Configuring MongoDB indexes.");
 			await statisticsService.CreateIndexes();
 
-			logger.LogInformation("Configuring CloudStorage.");
+			logger.LogInformation("Initializing MongoDB CloudStorage.");
 			await cloudStorageService.UpdateSystemfiles();
+
+			logger.LogInformation("Initializing MongoDB Clients.");
+			await clientService.Update(new Client(
+				ClientIdentification.Launcher.ID,
+				ClientIdentification.Launcher.Secret,
+				nameof(ClientIdentification.Launcher) + " (our website)"
+			));
+			await clientService.Update(new Client(
+				ClientIdentification.Game.ID,
+				ClientIdentification.Game.Secret,
+				nameof(ClientIdentification.Game)
+			));
+			await clientService.Update(new Client(
+				ClientIdentification.ServerInstance.ID,
+				ClientIdentification.ServerInstance.Secret,
+				nameof(ClientIdentification.ServerInstance)
+			));
 		}
 
 		public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/UT4MasterServer/Services/ApplicationStartupService.cs
+++ b/UT4MasterServer/Services/ApplicationStartupService.cs
@@ -31,17 +31,17 @@ namespace UT4MasterServer.Services
 			await cloudStorageService.UpdateSystemfiles();
 
 			logger.LogInformation("Initializing MongoDB Clients.");
-			await clientService.Update(new Client(
+			await clientService.UpdateAsync(new Client(
 				ClientIdentification.Launcher.ID,
 				ClientIdentification.Launcher.Secret,
 				nameof(ClientIdentification.Launcher) + " (our website)"
 			));
-			await clientService.Update(new Client(
+			await clientService.UpdateAsync(new Client(
 				ClientIdentification.Game.ID,
 				ClientIdentification.Game.Secret,
 				nameof(ClientIdentification.Game)
 			));
-			await clientService.Update(new Client(
+			await clientService.UpdateAsync(new Client(
 				ClientIdentification.ServerInstance.ID,
 				ClientIdentification.ServerInstance.Secret,
 				nameof(ClientIdentification.ServerInstance)

--- a/UT4MasterServer/Services/ClientService.cs
+++ b/UT4MasterServer/Services/ClientService.cs
@@ -15,7 +15,7 @@ public class ClientService
 		collection = dbContext.Database.GetCollection<Client>("clients");
 	}
 
-	public async Task<bool?> Update(Client client)
+	public async Task<bool?> UpdateAsync(Client client)
 	{
 		var options = new ReplaceOptions() { IsUpsert = true };
 		var result = await collection.ReplaceOneAsync(x => x.ID == client.ID, client, options);
@@ -24,21 +24,21 @@ public class ClientService
 		return result.ModifiedCount == 1;
 	}
 
-	public async Task<Client?> Get(EpicID id)
+	public async Task<Client?> GetAsync(EpicID id)
 	{
 		var options = new FindOptions<Client>() { Limit = 1 };
 		var cursor = await collection.FindAsync(x => x.ID == id, options);
 		return await cursor.SingleOrDefaultAsync();
 	}
 
-	public async Task<Client?> Get(EpicID id, EpicID secret)
+	public async Task<Client?> GetAsync(EpicID id, string secret)
 	{
 		var options = new FindOptions<Client>() { Limit = 1 };
 		var cursor = await collection.FindAsync(x => x.ID == id && x.Secret == secret, options);
 		return await cursor.SingleOrDefaultAsync();
 	}
 
-	public async Task<List<Client>> List()
+	public async Task<List<Client>> ListAsync()
 	{
 		var options = new FindOptions<Client>() { Limit = 1 };
 		var cursor = await collection.FindAsync(x => true, options);

--- a/UT4MasterServer/Services/ClientService.cs
+++ b/UT4MasterServer/Services/ClientService.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.DataProtection;
+using MongoDB.Driver;
+using System.Net.Sockets;
+using UT4MasterServer.Models;
+using UT4MasterServer.Other;
+
+namespace UT4MasterServer.Services;
+
+public class ClientService
+{
+	private readonly IMongoCollection<Client> collection;
+
+	public ClientService(DatabaseContext dbContext)
+	{
+		collection = dbContext.Database.GetCollection<Client>("clients");
+	}
+
+	public async Task<Client?> Get(EpicID id)
+	{
+		var options = new FindOptions<Client>() { Limit = 1 };
+		var cursor = await collection.FindAsync(x => x.ID == id, options);
+		return await cursor.SingleOrDefaultAsync();
+	}
+
+	public async Task<Client?> Get(EpicID id, EpicID secret)
+	{
+		var options = new FindOptions<Client>() { Limit = 1 };
+		var cursor = await collection.FindAsync(x => x.ID == id && x.Secret == secret, options);
+		return await cursor.SingleOrDefaultAsync();
+	}
+
+	public async Task<List<Client>> List()
+	{
+		var options = new FindOptions<Client>() { Limit = 1 };
+		var cursor = await collection.FindAsync(x => true, options);
+		return await cursor.ToListAsync();
+	}
+}

--- a/UT4MasterServer/Services/ClientService.cs
+++ b/UT4MasterServer/Services/ClientService.cs
@@ -15,6 +15,15 @@ public class ClientService
 		collection = dbContext.Database.GetCollection<Client>("clients");
 	}
 
+	public async Task<bool?> Update(Client client)
+	{
+		var options = new ReplaceOptions() { IsUpsert = true };
+		var result = await collection.ReplaceOneAsync(x => x.ID == client.ID, client, options);
+		if (!result.IsAcknowledged)
+			return null;
+		return result.ModifiedCount == 1;
+	}
+
 	public async Task<Client?> Get(EpicID id)
 	{
 		var options = new FindOptions<Client>() { Limit = 1 };

--- a/UT4MasterServer/Services/TrustedGameServerService.cs
+++ b/UT4MasterServer/Services/TrustedGameServerService.cs
@@ -13,13 +13,10 @@ public class TrustedGameServerService
 		collection = dbContext.Database.GetCollection<TrustedGameServer>("trustedservers");
 	}
 
-	public async Task<TrustedGameServer?> Get(EpicID id, EpicID secret)
+	public async Task<TrustedGameServer?> Get(EpicID id)
 	{
-		var options = new FindOptions<TrustedGameServer>()
-		{
-			Limit = 1
-		};
-		var cursor = await collection.FindAsync(x => x.ID == id && x.Secret == secret, options);
+		var options = new FindOptions<TrustedGameServer>() { Limit = 1 };
+		var cursor = await collection.FindAsync(x => x.ID == id, options);
 		return await cursor.SingleOrDefaultAsync();
 	}
 }

--- a/UT4MasterServer/Services/TrustedGameServerService.cs
+++ b/UT4MasterServer/Services/TrustedGameServerService.cs
@@ -13,7 +13,7 @@ public class TrustedGameServerService
 		collection = dbContext.Database.GetCollection<TrustedGameServer>("trustedservers");
 	}
 
-	public async Task<TrustedGameServer?> Get(EpicID id)
+	public async Task<TrustedGameServer?> GetAsync(EpicID id)
 	{
 		var options = new FindOptions<TrustedGameServer>() { Limit = 1 };
 		var cursor = await collection.FindAsync(x => x.ID == id, options);

--- a/UT4MasterServer/Services/TrustedGameServerService.cs
+++ b/UT4MasterServer/Services/TrustedGameServerService.cs
@@ -1,0 +1,25 @@
+using MongoDB.Driver;
+using UT4MasterServer.Models;
+using UT4MasterServer.Other;
+
+namespace UT4MasterServer.Services;
+
+public class TrustedGameServerService
+{
+	private readonly IMongoCollection<TrustedGameServer> collection;
+
+	public TrustedGameServerService(DatabaseContext dbContext)
+	{
+		collection = dbContext.Database.GetCollection<TrustedGameServer>("trustedservers");
+	}
+
+	public async Task<TrustedGameServer?> Get(EpicID id, EpicID secret)
+	{
+		var options = new FindOptions<TrustedGameServer>()
+		{
+			Limit = 1
+		};
+		var cursor = await collection.FindAsync(x => x.ID == id && x.Secret == secret, options);
+		return await cursor.SingleOrDefaultAsync();
+	}
+}


### PR DESCRIPTION
- Add simple permissions to account
- Add `clients` collection to db which lists all allowed client ID:Secret authorization pairs
- Add `trustedservers` collection listing all client ids which are to be considered trusted server instances
- Try to mimic epic's logic when handling GameServers instead of a secure logic