### PR TITLE
Merge old statistic records into one

### DIFF
--- a/UT4MasterServer/Enums/StatisticWindow.cs
+++ b/UT4MasterServer/Enums/StatisticWindow.cs
@@ -4,6 +4,7 @@ public enum StatisticWindow
 {
 	AllTime = 0,
 	Daily = 1,
+	DailyMerged = 2,
 	Weekly = 7,
 	Monthly = 30,
 }

--- a/UT4MasterServer/Models/ApplicationSettings.cs
+++ b/UT4MasterServer/Models/ApplicationSettings.cs
@@ -1,6 +1,6 @@
 ﻿namespace UT4MasterServer.Models;
 
-public class ApplicationSettings
+public sealed class ApplicationSettings
 {
 	public string DatabaseConnectionString { get; set; } = string.Empty;
 	public string DatabaseName { get; set; } = string.Empty;
@@ -31,4 +31,13 @@ public class ApplicationSettings
 	/// </summary>
 	public List<string> ProxyServers { get; set; } = new List<string>();
 
+	/// <summary>
+	/// Time zone in which merging old statistics is executed
+	/// </summary>
+	public string MergeOldStatisticsTimeZone { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Hour at which merging old statistics is executed
+	/// </summary>
+	public int MergeOldStatisticsHour { get; set; }
 }

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -919,25 +919,19 @@ public class StatisticBase
 
 	private void ValidateMultiAndSpreeKillStatistic(int? value, int multiplier, string statisticName, List<string> flaggedFields)
 	{
-		if (value.HasValue)
+		if (value.HasValue && (!Kills.HasValue || (Kills.HasValue && value.Value * multiplier > Kills.Value)))
 		{
-			if (!Kills.HasValue || (Kills.HasValue && value.Value * multiplier > Kills.Value))
-			{
-				flaggedFields.Add(statisticName);
-				flaggedFields.Add(nameof(Kills));
-			}
+			flaggedFields.Add(statisticName);
+			flaggedFields.Add(nameof(Kills));
 		}
 	}
 
 	private void ValidateTimeStatistic(double? value, string statisticName, List<string> flaggedFields)
 	{
-		if (value.HasValue)
+		if (value.HasValue && TimePlayed.HasValue && value.Value > TimePlayed.Value)
 		{
-			if (TimePlayed.HasValue && value.Value > TimePlayed.Value)
-			{
-				flaggedFields.Add(statisticName);
-				flaggedFields.Add(nameof(TimePlayed));
-			}
+			flaggedFields.Add(statisticName);
+			flaggedFields.Add(nameof(TimePlayed));
 		}
 	}
 

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -342,7 +342,7 @@ public class StatisticBase
 			LightningRifleSecondaryKills,
 			RedeemerKills,
 			InstagibKills,
-			TelefragKills
+			TelefragKills,
 		}.Sum() ?? 0;
 
 		#region Quick Look Validations

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -316,337 +316,6 @@ public class StatisticBase
 		TeamKills = statisticBase.TeamKills;
 	}
 
-	public List<string> Validate()
-	{
-		var flaggedFields = new List<string>();
-
-		var totalKills = new int?[]
-		{
-			ImpactHammerKills,
-			EnforcerKills,
-			BioRifleKills,
-			BioLauncherKills,
-			ShockBeamKills,
-			ShockCoreKills,
-			ShockComboKills,
-			LinkKills,
-			LinkBeamKills,
-			MinigunKills,
-			MinigunShardKills,
-			FlakShardKills,
-			FlakShellKills,
-			RocketKills,
-			SniperKills,
-			SniperHeadshotKills,
-			LightningRiflePrimaryKills,
-			LightningRifleSecondaryKills,
-			RedeemerKills,
-			InstagibKills,
-			TelefragKills,
-		}.Sum() ?? 0;
-
-		#region Quick Look Validations
-
-		// Since this is added after match, this property should be only 1
-		if (MatchesPlayed.HasValue && MatchesPlayed.Value > 1)
-		{
-			flaggedFields.Add(nameof(MatchesPlayed));
-		}
-		// Since this is added after match, this property should be only 1
-		if (MatchesQuit.HasValue && MatchesQuit.Value > 1)
-		{
-			flaggedFields.Add(nameof(MatchesQuit));
-		}
-		// You shouldn't have both Wins and Losses value available at the same time
-		if (MatchesPlayed.HasValue && MatchesQuit.HasValue && MatchesPlayed.Value > 0 && MatchesQuit.Value > 0)
-		{
-			flaggedFields.Add(nameof(MatchesPlayed));
-			flaggedFields.Add(nameof(MatchesQuit));
-		}
-		// Since this is added after match, this property should be only 1
-		if (Wins.HasValue && Wins.Value > 1)
-		{
-			flaggedFields.Add(nameof(Wins));
-		}
-		// Since this is added after match, this property should be only 1
-		if (Losses.HasValue && Losses.Value > 1)
-		{
-			flaggedFields.Add(nameof(Losses));
-		}
-		// You shouldn't have both Wins and Losses value available at the same time
-		if (Wins.HasValue && Losses.HasValue && Wins.Value > 0 && Losses.Value > 0)
-		{
-			flaggedFields.Add(nameof(Wins));
-			flaggedFields.Add(nameof(Losses));
-		}
-		// Maximum time for custom game is 60 minutes (1 minute is added just to be sure)
-		if (TimePlayed.HasValue && TimePlayed.Value > (60 * 60) + 60)
-		{
-			flaggedFields.Add(nameof(TimePlayed));
-		}
-		if (Kills.HasValue)
-		{
-			// Kills are reported if you manage to achieve 1 kill each 1.5 second
-			if (TimePlayed.HasValue && Kills.Value > (TimePlayed.Value / 1.5))
-			{
-				flaggedFields.Add(nameof(Kills));
-				flaggedFields.Add(nameof(TimePlayed));
-			}
-			// Kills are reported if they don't match the sum of individual weapon kills
-			if (Kills.Value != totalKills)
-			{
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Deaths are reported if you manage to achieve 1 death each 2 seconds
-		if (Deaths.HasValue && TimePlayed.HasValue && Deaths.Value > (TimePlayed.Value / 2))
-		{
-			flaggedFields.Add(nameof(Deaths));
-			flaggedFields.Add(nameof(TimePlayed));
-		}
-		// Suicides are reported if you manage to achieve 1 suicide each 2 seconds
-		if (Suicides.HasValue && TimePlayed.HasValue && Suicides.Value > (TimePlayed.Value / 2))
-		{
-			flaggedFields.Add(nameof(Suicides));
-			flaggedFields.Add(nameof(TimePlayed));
-		}
-
-		#endregion
-
-		#region Kill Achievements Validations
-
-		// Cannot have double kills without or more than actual kills                                                                   
-		if (MultiKillLevel0.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel0.Value * 2 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(MultiKillLevel0));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Cannot have multi kills without or more than actual kills
-		if (MultiKillLevel1.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel1.Value * 3 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(MultiKillLevel1));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Cannot have ultra kills without or more than actual kills
-		if (MultiKillLevel2.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && MultiKillLevel2.Value * 4 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(MultiKillLevel2));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Cannot have killing spree without or more than actual kills
-		if (SpreeKillLevel0.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel0.Value * 5 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(SpreeKillLevel0));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Cannot have rampages without or more than actual kills
-		if (SpreeKillLevel1.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel1.Value * 10 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(SpreeKillLevel1));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Cannot have dominatings without or more than actual kills
-		if (SpreeKillLevel2.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel2.Value * 15 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(SpreeKillLevel2));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-		// Cannot have unstoppables without or more than actual kills
-		if (SpreeKillLevel3.HasValue)
-		{
-			if (!Kills.HasValue || (Kills.HasValue && SpreeKillLevel3.Value * 20 > Kills.Value))
-			{
-				flaggedFields.Add(nameof(SpreeKillLevel3));
-				flaggedFields.Add(nameof(Kills));
-			}
-		}
-
-		#endregion
-
-		#region Power Up Achievements Validations
-
-		if (UDamageTime.HasValue)
-		{
-			// UDamage time cannot be longer than match time
-			if (TimePlayed.HasValue && UDamageTime.Value > TimePlayed.Value)
-			{
-				flaggedFields.Add(nameof(UDamageTime));
-				flaggedFields.Add(nameof(TimePlayed));
-			}
-		}
-		if (BerserkTime.HasValue)
-		{
-			// BerserkTime time cannot be longer than match time
-			if (TimePlayed.HasValue && BerserkTime.Value > TimePlayed.Value)
-			{
-				flaggedFields.Add(nameof(BerserkTime));
-				flaggedFields.Add(nameof(TimePlayed));
-			}
-		}
-		if (InvisibilityTime.HasValue)
-		{
-			// InvisibilityTime time cannot be longer than match time
-			if (TimePlayed.HasValue && InvisibilityTime.Value > TimePlayed.Value)
-			{
-				flaggedFields.Add(nameof(InvisibilityTime));
-				flaggedFields.Add(nameof(TimePlayed));
-			}
-		}
-
-		#endregion
-
-		#region Weapon Stats Validations
-
-		// Impact Hammer kills are reported if they are more than the actual kills
-		if (ImpactHammerKills.HasValue && (!Kills.HasValue || ImpactHammerKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(ImpactHammerKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Enforcer kills are reported if they are more than the actual kills
-		if (EnforcerKills.HasValue && (!Kills.HasValue || EnforcerKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(EnforcerKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Bio Rifle kills are reported if they are more than the actual kills
-		if (BioRifleKills.HasValue && (!Kills.HasValue || BioRifleKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(BioRifleKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Grenade Launcher kills are reported if they are more than the actual kills
-		if (BioLauncherKills.HasValue && (!Kills.HasValue || BioLauncherKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(BioLauncherKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Shock Beam kills are reported if they are more than the actual kills
-		if (ShockBeamKills.HasValue && (!Kills.HasValue || ShockBeamKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(ShockBeamKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Shock Core kills are reported if they are more than the actual kills
-		if (ShockCoreKills.HasValue && (!Kills.HasValue || ShockCoreKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(ShockCoreKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Shock Combo kills are reported if they are more than the actual kills
-		if (ShockComboKills.HasValue && (!Kills.HasValue || ShockComboKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(ShockComboKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Link kills are reported if they are more than the actual kills
-		if (LinkKills.HasValue && (!Kills.HasValue || LinkKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(LinkKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Link Beam kills are reported if they are more than the actual kills
-		if (LinkBeamKills.HasValue && (!Kills.HasValue || LinkBeamKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(LinkBeamKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Minigun kills are reported if they are more than the actual kills
-		if (MinigunKills.HasValue && (!Kills.HasValue || MinigunKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(MinigunKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Minigun Shard kills are reported if they are more than the actual kills
-		if (MinigunShardKills.HasValue && (!Kills.HasValue || MinigunShardKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(MinigunShardKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Flak Shard kills are reported if they are more than the actual kills
-		if (FlakShardKills.HasValue && (!Kills.HasValue || FlakShardKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(FlakShardKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Flak Shell kills are reported if they are more than the actual kills
-		if (FlakShellKills.HasValue && (!Kills.HasValue || FlakShellKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(FlakShellKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Rocket kills are reported if they are more than the actual kills
-		if (RocketKills.HasValue && (!Kills.HasValue || RocketKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(RocketKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Sniper kills are reported if they are more than the actual kills
-		if (SniperKills.HasValue && (!Kills.HasValue || SniperKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(SniperKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Sniper Headshot kills are reported if they are more than the actual kills
-		if (SniperHeadshotKills.HasValue && (!Kills.HasValue || SniperHeadshotKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(SniperHeadshotKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Lightning Rifle Primary kills are reported if they are more than the actual kills
-		if (LightningRiflePrimaryKills.HasValue && (!Kills.HasValue || LightningRiflePrimaryKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(LightningRiflePrimaryKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Lightning Rifle Secondary kills are reported if they are more than the actual kills
-		if (LightningRifleSecondaryKills.HasValue && (!Kills.HasValue || LightningRifleSecondaryKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(LightningRifleSecondaryKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Redeemer kills are reported if they are more than the actual kills
-		if (RedeemerKills.HasValue && (!Kills.HasValue || RedeemerKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(RedeemerKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Instagib kills are reported if they are more than the actual kills
-		if (InstagibKills.HasValue && (!Kills.HasValue || InstagibKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(InstagibKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-		// Telefrag kills are reported if they are more than the actual kills
-		if (TelefragKills.HasValue && (!Kills.HasValue || TelefragKills.Value > Kills.Value))
-		{
-			flaggedFields.Add(nameof(TelefragKills));
-			flaggedFields.Add(nameof(Kills));
-		}
-
-		#endregion
-
-		return flaggedFields;
-	}
-
 	#region Quick Look
 	[BsonIgnoreIfNull]
 	public int? SkillRating { get; set; }
@@ -1109,5 +778,177 @@ public class StatisticBase
 
 	[BsonIgnoreIfNull]
 	public int? TeamKills { get; set; }
+	#endregion
+
+	#region Validation
+	public List<string> Validate()
+	{
+		var flaggedFields = new List<string>();
+
+		var totalKills = new int?[]
+		{
+			ImpactHammerKills,
+			EnforcerKills,
+			BioRifleKills,
+			BioLauncherKills,
+			ShockBeamKills,
+			ShockCoreKills,
+			ShockComboKills,
+			LinkKills,
+			LinkBeamKills,
+			MinigunKills,
+			MinigunShardKills,
+			FlakShardKills,
+			FlakShellKills,
+			RocketKills,
+			SniperKills,
+			SniperHeadshotKills,
+			LightningRiflePrimaryKills,
+			LightningRifleSecondaryKills,
+			RedeemerKills,
+			InstagibKills,
+			TelefragKills,
+		}.Sum() ?? 0;
+
+		#region Quick Look Validations
+		// These statistics cannot be more than 1
+		ValidateMaxValueForStatistic(MatchesPlayed, 1, nameof(MatchesPlayed), flaggedFields);
+		ValidateMaxValueForStatistic(MatchesQuit, 1, nameof(MatchesQuit), flaggedFields);
+		ValidateMaxValueForStatistic(Wins, 1, nameof(Wins), flaggedFields);
+		ValidateMaxValueForStatistic(Losses, 1, nameof(Losses), flaggedFields);
+
+		// These statistics cannot exist at the same time
+		ValidateIfBothStatisticsExist(MatchesPlayed, MatchesQuit, nameof(MatchesPlayed), nameof(MatchesQuit), flaggedFields);
+		ValidateIfBothStatisticsExist(Wins, Losses, nameof(Wins), nameof(Losses), flaggedFields);
+
+		// Maximum time for custom game is 60 minutes (1 minute is added just to be sure)
+		if (TimePlayed.HasValue && TimePlayed.Value > (60 * 60) + 60)
+		{
+			flaggedFields.Add(nameof(TimePlayed));
+		}
+		if (Kills.HasValue)
+		{
+			// Kills are reported if you manage to achieve 1 kill each 1.5 second
+			ValidateStatisticsAgainstTimePlayed(Kills, 1.5, nameof(Kills), flaggedFields);
+
+			// Kills are reported if they don't match the sum of individual weapon kills
+			if (Kills.Value != totalKills)
+			{
+				flaggedFields.Add(nameof(Kills));
+			}
+		}
+
+		// Deaths/suicides are reported if you manage to achieve 1 each 2 seconds
+		ValidateStatisticsAgainstTimePlayed(Deaths, 2, nameof(Deaths), flaggedFields);
+		ValidateStatisticsAgainstTimePlayed(Suicides, 2, nameof(Suicides), flaggedFields);
+		#endregion
+
+		#region Kill Achievements Validations
+		// Cannot have double/multi/ultra kills without or more than actual kills
+		ValidateMultiAndSpreeKillStatistic(MultiKillLevel0, 2, nameof(MultiKillLevel0), flaggedFields);
+		ValidateMultiAndSpreeKillStatistic(MultiKillLevel1, 3, nameof(MultiKillLevel1), flaggedFields);
+		ValidateMultiAndSpreeKillStatistic(MultiKillLevel2, 4, nameof(MultiKillLevel2), flaggedFields);
+
+		// Cannot have killing spree/rampages/dominatings/unstoppables without or more than actual kills
+		ValidateMultiAndSpreeKillStatistic(SpreeKillLevel0, 5, nameof(SpreeKillLevel0), flaggedFields);
+		ValidateMultiAndSpreeKillStatistic(SpreeKillLevel1, 10, nameof(SpreeKillLevel1), flaggedFields);
+		ValidateMultiAndSpreeKillStatistic(SpreeKillLevel2, 15, nameof(SpreeKillLevel2), flaggedFields);
+		ValidateMultiAndSpreeKillStatistic(SpreeKillLevel3, 20, nameof(SpreeKillLevel3), flaggedFields);
+		#endregion
+
+		#region Power Up Achievements Validations
+		// UDamage/Berserk/Invisibility time cannot be longer than match time
+		ValidateTimeStatistic(UDamageTime, nameof(UDamageTime), flaggedFields);
+		ValidateTimeStatistic(BerserkTime, nameof(BerserkTime), flaggedFields);
+		ValidateTimeStatistic(InvisibilityTime, nameof(InvisibilityTime), flaggedFields);
+		#endregion
+
+		#region Weapon Stats Validations
+		// Per-weapon kills are reported if they are more than the actual kills or if actual kills are missing
+		ValidatePerWeaponKillStatistic(ImpactHammerKills, nameof(ImpactHammerKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(EnforcerKills, nameof(EnforcerKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(BioRifleKills, nameof(BioRifleKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(BioLauncherKills, nameof(BioLauncherKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(ShockBeamKills, nameof(ShockBeamKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(ShockCoreKills, nameof(ShockCoreKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(ShockComboKills, nameof(ShockComboKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(LinkKills, nameof(LinkKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(LinkBeamKills, nameof(LinkBeamKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(MinigunKills, nameof(MinigunKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(MinigunShardKills, nameof(MinigunShardKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(FlakShardKills, nameof(FlakShardKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(FlakShellKills, nameof(FlakShellKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(RocketKills, nameof(RocketKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(SniperKills, nameof(SniperKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(SniperHeadshotKills, nameof(SniperHeadshotKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(LightningRiflePrimaryKills, nameof(LightningRiflePrimaryKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(LightningRifleSecondaryKills, nameof(LightningRifleSecondaryKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(RedeemerKills, nameof(RedeemerKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(InstagibKills, nameof(InstagibKills), flaggedFields);
+		ValidatePerWeaponKillStatistic(TelefragKills, nameof(TelefragKills), flaggedFields);
+		#endregion
+
+		return flaggedFields;
+	}
+
+	private static void ValidateMaxValueForStatistic(int? value, int maxValue, string statisticName, List<string> flaggedFields)
+	{
+		if (value.HasValue && value.Value > maxValue)
+		{
+			flaggedFields.Add(statisticName);
+		}
+	}
+
+	private static void ValidateIfBothStatisticsExist(int? firstValue, int? secondValue, string firstStatistic, string secondStatistic, List<string> flaggedFields)
+	{
+		if (firstValue.HasValue && secondValue.HasValue && firstValue.Value > 0 && secondValue.Value > 0)
+		{
+			flaggedFields.Add(firstStatistic);
+			flaggedFields.Add(secondStatistic);
+		}
+	}
+
+	private void ValidateStatisticsAgainstTimePlayed(int? value, double maxValuePerSecond, string statisticName, List<string> flaggedFields)
+	{
+		if (value.HasValue && TimePlayed.HasValue && value.Value > (TimePlayed.Value / maxValuePerSecond))
+		{
+			flaggedFields.Add(statisticName);
+			flaggedFields.Add(nameof(TimePlayed));
+		}
+	}
+
+	private void ValidateMultiAndSpreeKillStatistic(int? value, int multiplier, string statisticName, List<string> flaggedFields)
+	{
+		if (value.HasValue)
+		{
+			if (!Kills.HasValue || (Kills.HasValue && value.Value * multiplier > Kills.Value))
+			{
+				flaggedFields.Add(statisticName);
+				flaggedFields.Add(nameof(Kills));
+			}
+		}
+	}
+
+	private void ValidateTimeStatistic(double? value, string statisticName, List<string> flaggedFields)
+	{
+		if (value.HasValue)
+		{
+			if (TimePlayed.HasValue && value.Value > TimePlayed.Value)
+			{
+				flaggedFields.Add(statisticName);
+				flaggedFields.Add(nameof(TimePlayed));
+			}
+		}
+	}
+
+	private void ValidatePerWeaponKillStatistic(int? value, string statisticName, List<string> flaggedFields)
+	{
+		if (value.HasValue && (!Kills.HasValue || value.Value > Kills.Value))
+		{
+			flaggedFields.Add(statisticName);
+			flaggedFields.Add(nameof(Kills));
+		}
+	}
+
 	#endregion
 }

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -826,6 +826,7 @@ public class StatisticBase
 		{
 			flaggedFields.Add(nameof(TimePlayed));
 		}
+
 		if (Kills.HasValue)
 		{
 			// Kills are reported if you manage to achieve 1 kill each 1.5 second

--- a/UT4MasterServer/Models/StatisticBase.cs
+++ b/UT4MasterServer/Models/StatisticBase.cs
@@ -516,109 +516,130 @@ public class StatisticBase
 		#region Weapon Stats Validations
 
 		// Impact Hammer kills are reported if they are more than the actual kills
-		if (ImpactHammerKills.HasValue && Kills.HasValue && ImpactHammerKills.Value > Kills.Value)
+		if (ImpactHammerKills.HasValue && (!Kills.HasValue || ImpactHammerKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(ImpactHammerKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Enforcer kills are reported if they are more than the actual kills
-		if (EnforcerKills.HasValue && Kills.HasValue && EnforcerKills.Value > Kills.Value)
+		if (EnforcerKills.HasValue && (!Kills.HasValue || EnforcerKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(EnforcerKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Bio Rifle kills are reported if they are more than the actual kills
-		if (BioRifleKills.HasValue && Kills.HasValue && BioRifleKills.Value > Kills.Value)
+		if (BioRifleKills.HasValue && (!Kills.HasValue || BioRifleKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(BioRifleKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Grenade Launcher kills are reported if they are more than the actual kills
-		if (BioLauncherKills.HasValue && Kills.HasValue && BioLauncherKills.Value > Kills.Value)
+		if (BioLauncherKills.HasValue && (!Kills.HasValue || BioLauncherKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(BioLauncherKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Shock Beam kills are reported if they are more than the actual kills
-		if (ShockBeamKills.HasValue && Kills.HasValue && ShockBeamKills.Value > Kills.Value)
+		if (ShockBeamKills.HasValue && (!Kills.HasValue || ShockBeamKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(ShockBeamKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Shock Core kills are reported if they are more than the actual kills
-		if (ShockCoreKills.HasValue && Kills.HasValue && ShockCoreKills.Value > Kills.Value)
+		if (ShockCoreKills.HasValue && (!Kills.HasValue || ShockCoreKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(ShockCoreKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Shock Combo kills are reported if they are more than the actual kills
-		if (ShockComboKills.HasValue && Kills.HasValue && ShockComboKills.Value > Kills.Value)
+		if (ShockComboKills.HasValue && (!Kills.HasValue || ShockComboKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(ShockComboKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Link kills are reported if they are more than the actual kills
-		if (LinkKills.HasValue && Kills.HasValue && LinkKills.Value > Kills.Value)
+		if (LinkKills.HasValue && (!Kills.HasValue || LinkKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(LinkKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Link Beam kills are reported if they are more than the actual kills
-		if (LinkBeamKills.HasValue && Kills.HasValue && LinkBeamKills.Value > Kills.Value)
+		if (LinkBeamKills.HasValue && (!Kills.HasValue || LinkBeamKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(LinkBeamKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Minigun kills are reported if they are more than the actual kills
-		if (MinigunKills.HasValue && Kills.HasValue && MinigunKills.Value > Kills.Value)
+		if (MinigunKills.HasValue && (!Kills.HasValue || MinigunKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(MinigunKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Minigun Shard kills are reported if they are more than the actual kills
-		if (MinigunShardKills.HasValue && Kills.HasValue && MinigunShardKills.Value > Kills.Value)
+		if (MinigunShardKills.HasValue && (!Kills.HasValue || MinigunShardKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(MinigunShardKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Flak Shard kills are reported if they are more than the actual kills
-		if (FlakShardKills.HasValue && Kills.HasValue && FlakShardKills.Value > Kills.Value)
+		if (FlakShardKills.HasValue && (!Kills.HasValue || FlakShardKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(FlakShardKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Flak Shell kills are reported if they are more than the actual kills
-		if (FlakShellKills.HasValue && Kills.HasValue && FlakShellKills.Value > Kills.Value)
+		if (FlakShellKills.HasValue && (!Kills.HasValue || FlakShellKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(FlakShellKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Rocket kills are reported if they are more than the actual kills
-		if (RocketKills.HasValue && Kills.HasValue && RocketKills.Value > Kills.Value)
+		if (RocketKills.HasValue && (!Kills.HasValue || RocketKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(RocketKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Sniper kills are reported if they are more than the actual kills
-		if (SniperKills.HasValue && Kills.HasValue && SniperKills.Value > Kills.Value)
+		if (SniperKills.HasValue && (!Kills.HasValue || SniperKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(SniperKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Sniper Headshot kills are reported if they are more than the actual kills
-		if (SniperHeadshotKills.HasValue && Kills.HasValue && SniperHeadshotKills.Value > Kills.Value)
+		if (SniperHeadshotKills.HasValue && (!Kills.HasValue || SniperHeadshotKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(SniperHeadshotKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Lightning Rifle Primary kills are reported if they are more than the actual kills
-		if (LightningRiflePrimaryKills.HasValue && Kills.HasValue && LightningRiflePrimaryKills.Value > Kills.Value)
+		if (LightningRiflePrimaryKills.HasValue && (!Kills.HasValue || LightningRiflePrimaryKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(LightningRiflePrimaryKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Lightning Rifle Secondary kills are reported if they are more than the actual kills
-		if (LightningRifleSecondaryKills.HasValue && Kills.HasValue && LightningRifleSecondaryKills.Value > Kills.Value)
+		if (LightningRifleSecondaryKills.HasValue && (!Kills.HasValue || LightningRifleSecondaryKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(LightningRifleSecondaryKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Redeemer kills are reported if they are more than the actual kills
-		if (RedeemerKills.HasValue && Kills.HasValue && RedeemerKills.Value > Kills.Value)
+		if (RedeemerKills.HasValue && (!Kills.HasValue || RedeemerKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(RedeemerKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Instagib kills are reported if they are more than the actual kills
-		if (InstagibKills.HasValue && Kills.HasValue && InstagibKills.Value > Kills.Value)
+		if (InstagibKills.HasValue && (!Kills.HasValue || InstagibKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(InstagibKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 		// Telefrag kills are reported if they are more than the actual kills
-		if (TelefragKills.HasValue && Kills.HasValue && TelefragKills.Value > Kills.Value)
+		if (TelefragKills.HasValue && (!Kills.HasValue || TelefragKills.Value > Kills.Value))
 		{
 			flaggedFields.Add(nameof(TelefragKills));
+			flaggedFields.Add(nameof(Kills));
 		}
 
 		#endregion

--- a/UT4MasterServer/Services/ApplicationBackgroundService.cs
+++ b/UT4MasterServer/Services/ApplicationBackgroundService.cs
@@ -1,66 +1,76 @@
 using Microsoft.Extensions.Options;
-using MongoDB.Driver;
 using UT4MasterServer.Models;
 
-namespace UT4MasterServer.Services
+namespace UT4MasterServer.Services;
+
+public class ApplicationBackgroundCleanupService : IHostedService, IDisposable
 {
-	public class ApplicationBackgroundCleanupService : IHostedService, IDisposable
+	private readonly ILogger<ApplicationStartupService> logger;
+	private readonly ApplicationSettings settings;
+	private readonly IServiceProvider services;
+
+	private Timer? tmrExpiredSessionDeletor;
+	private DateTime? lastDateMergeStatisticsExecuted;
+
+	public ApplicationBackgroundCleanupService(
+		ILogger<ApplicationStartupService> logger,
+		IOptions<ApplicationSettings> settings,
+		IServiceProvider services
+		)
 	{
-		private readonly ILogger<ApplicationStartupService> logger;
-		private readonly IServiceProvider services;
+		this.logger = logger;
+		this.settings = settings.Value;
+		this.services = services;
+	}
 
-		private Timer? tmrExpiredSessionDeletor;
-
-		public ApplicationBackgroundCleanupService(
-			ILogger<ApplicationStartupService> logger, ILogger<StatisticsService> statsLogger,
-			IOptions<ApplicationSettings> settings,
-			IServiceProvider services
-			)
-		{
-			this.logger = logger;
-			this.services = services;
-		}
-
-		public Task StartAsync(CancellationToken cancellationToken)
-		{
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
 #if DEBUG
-			var period = TimeSpan.FromMinutes(1);
+		var period = TimeSpan.FromMinutes(1);
 #else
-			var period = TimeSpan.FromMinutes(30);
+		var period = TimeSpan.FromMinutes(30);
 #endif
-			tmrExpiredSessionDeletor = new Timer(DoWork, null, TimeSpan.Zero, period);
-			return Task.CompletedTask;
-		}
+		tmrExpiredSessionDeletor = new Timer(DoWork, null, TimeSpan.Zero, period);
+		return Task.CompletedTask;
+	}
 
-		public Task StopAsync(CancellationToken cancellationToken)
-		{
-			tmrExpiredSessionDeletor?.Change(Timeout.Infinite, 0);
-			return Task.CompletedTask;
-		}
+	public Task StopAsync(CancellationToken cancellationToken)
+	{
+		tmrExpiredSessionDeletor?.Change(Timeout.Infinite, 0);
+		return Task.CompletedTask;
+	}
 
-		private void DoWork(object? state)
+	private void DoWork(object? state)
+	{
+		Task.Run(async () =>
 		{
-			Task.Run(async () =>
+			using var scope = services.CreateScope();
+
+			var sessionService = scope.ServiceProvider.GetRequiredService<SessionService>();
+			var deleteCount = await sessionService.RemoveAllExpiredSessionsAsync();
+			if (deleteCount > 0)
+				logger.LogInformation("Background task deleted {DeleteCount} expired sessions.", deleteCount);
+
+			var matchmakingService = scope.ServiceProvider.GetRequiredService<MatchmakingService>();
+			deleteCount = await matchmakingService.RemoveAllStaleAsync();
+			if (deleteCount > 0)
+				logger.LogInformation("Background task deleted {DeleteCount} stale game servers.", deleteCount);
+
+			// Merging old daily statistic records
+			var currentTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById(settings.MergeOldStatisticsTimeZone));
+			if (currentTime.Hour == settings.MergeOldStatisticsHour &&
+			   (!lastDateMergeStatisticsExecuted.HasValue || lastDateMergeStatisticsExecuted.Value.Date != currentTime.Date))
 			{
-				using (var scope = services.CreateScope())
-				{
-					var sessionService = scope.ServiceProvider.GetRequiredService<SessionService>();
-					var deleteCount = await sessionService.RemoveAllExpiredSessionsAsync();
-					if (deleteCount > 0)
-						logger.LogInformation("Background task deleted {DeleteCount} expired sessions.", deleteCount);
+				lastDateMergeStatisticsExecuted = currentTime.Date;
+				
+				var statisticsService = scope.ServiceProvider.GetRequiredService<StatisticsService>();
+				await statisticsService.MergeOldStatisticsAsync();
+			}
+		});
+	}
 
-					var matchmakingService = scope.ServiceProvider.GetRequiredService<MatchmakingService>();
-					deleteCount = await matchmakingService.RemoveAllStaleAsync();
-					if (deleteCount > 0)
-						logger.LogInformation("Background task deleted {DeleteCount} stale game servers.", deleteCount);
-				}
-
-			});
-		}
-
-		public void Dispose()
-		{
-			tmrExpiredSessionDeletor?.Dispose();
-		}
+	public void Dispose()
+	{
+		tmrExpiredSessionDeletor?.Dispose();
 	}
 }

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -42,7 +42,7 @@ public sealed class StatisticsService
 		}
 		var dateTo = DateTime.UtcNow.AddDays(1).Date;
 		var filter = Builders<Statistic>.Filter.Eq(f => f.AccountID, accountID) &
-					 Builders<Statistic>.Filter.Eq(f => f.Window, StatisticWindow.Daily) &
+					 Builders<Statistic>.Filter.In(f => f.Window, new[] { StatisticWindow.Daily, StatisticWindow.DailyMerged }) &
 					 Builders<Statistic>.Filter.Gte(f => f.CreatedAt, dateFrom) &
 					 Builders<Statistic>.Filter.Lt(f => f.CreatedAt, dateTo);
 

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -26,7 +26,7 @@ public sealed class StatisticsService
 		var statisticsIndexes = new List<CreateIndexModel<Statistic>>()
 			{
 				new CreateIndexModel<Statistic>(Builders<Statistic>.IndexKeys.Ascending(indexKey => indexKey.AccountID)),
-				new CreateIndexModel<Statistic>(Builders<Statistic>.IndexKeys.Ascending(indexKey => indexKey.CreatedAt))
+				new CreateIndexModel<Statistic>(Builders<Statistic>.IndexKeys.Ascending(indexKey => indexKey.CreatedAt)),
 			};
 		await statisticsCollection.Indexes.CreateManyAsync(statisticsIndexes);
 	}
@@ -274,7 +274,7 @@ public sealed class StatisticsService
 				AccountId = s.Key.AccountID,
 				CreatedAt = s.Key.Date,
 				Statistics = s.ToList(),
-				Count = s.Count()
+				Count = s.Count(),
 			})
 			.ToList();
 
@@ -397,7 +397,7 @@ public sealed class StatisticsService
 			var newAllTimeStatistics = new Statistic(newStatistic)
 			{
 				AccountID = newStatistic.AccountID,
-				Window = StatisticWindow.AllTime
+				Window = StatisticWindow.AllTime,
 			};
 
 			await statisticsCollection.InsertOneAsync(newAllTimeStatistics);
@@ -429,7 +429,7 @@ public sealed class StatisticsService
 						Name = element.Name,
 						Value = value,
 						Window = statisticWindow.ToString().ToLower(),
-						OwnerType = OwnerType.Default
+						OwnerType = OwnerType.Default,
 					});
 				}
 			}

--- a/UT4MasterServer/Services/StatisticsService.cs
+++ b/UT4MasterServer/Services/StatisticsService.cs
@@ -313,7 +313,7 @@ public sealed class StatisticsService
 
 				statisticIdsToDelete.AddRange(mergedStatisticsIds);
 
-				logger.LogInformation("Merged the following statistics into one record: {StatisticIds}.", string.Join(",", mergedStatisticsIds));
+				logger.LogInformation("Merged the following statistics into one record: {StatisticIds}.", string.Join(", ", mergedStatisticsIds));
 			}
 			// Statistics that have one record per day should be either modified or merged with already merged statistics
 			else
@@ -331,7 +331,7 @@ public sealed class StatisticsService
 
 					statisticIdsToDelete.AddRange(mergedStatisticsIds);
 
-					logger.LogInformation("Merged the following statistics into one record: {StatisticIds}.", string.Join(",", mergedStatisticsIds));
+					logger.LogInformation("Merged the following statistics into one record: {StatisticIds}.", string.Join(", ", mergedStatisticsIds));
 				}
 				else
 				{
@@ -349,7 +349,7 @@ public sealed class StatisticsService
 
 			var deleteFilter = Builders<Statistic>.Filter.In(f => f.ID, statisticIdsToDelete);
 			await statisticsCollection.DeleteManyAsync(deleteFilter);
-			logger.LogInformation("Deleting the following statistics: {StatisticIds}.", string.Join(",", statisticIdsToDelete));
+			logger.LogInformation("Deleting the following statistics: {StatisticIds}.", string.Join(", ", statisticIdsToDelete));
 		}
 
 		// Modifying Window and removing Flagged property for statistics which are single per day

--- a/UT4MasterServer/appsettings.json
+++ b/UT4MasterServer/appsettings.json
@@ -1,33 +1,28 @@
 {
-	"ApplicationSettings":
-	{
-		"DatabaseConnectionString": "mongodb://devroot:devroot@mongo:27017",
-		"DatabaseName": "ut4master",
-		"WebsiteDomain": "ut4.timiimit.com",
-		"AllowPasswordGrantType": true,
-		"ProxyClientIPHeader": "X-Forwarded-For",
-		"ProxyServers":
-		[
-			"172.20.0.1"
-		]
-	},
-	"Logging":
-	{
-		"LogLevel":
-		{
-			"Default": "Warning",
-			"Microsoft.AspNetCore": "Error"
-		}
-	},
-	"AllowedHosts": "*",
-	"Kestrel":
-	{
-		"Endpoints":
-		{
-			"Http":
-			{
-				"Url": "http://0.0.0.0:80"
-			}
-		}
-	}
+  "ApplicationSettings": {
+    "DatabaseConnectionString": "mongodb://devroot:devroot@mongo:27017",
+    "DatabaseName": "ut4master",
+    "WebsiteDomain": "ut4.timiimit.com",
+    "AllowPasswordGrantType": true,
+    "ProxyClientIPHeader": "X-Forwarded-For",
+    "ProxyServers": [
+      "172.20.0.1"
+    ],
+    "MergeOldStatisticsTimeZone": "Central European Standard Time",
+    "MergeOldStatisticsHour": 10
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Error"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:80"
+      }
+    }
+  }
 }


### PR DESCRIPTION
This job will be executed once per day at the time defined in the appsettings.

It will look for daily non-flagged statistic records that are older than 7 days, and merge them into one statistic record with `Window = DailyMerged`. If there is only one record per account per day, that record is only modified to have `Window = DailyMerged`.

Here are some examples of the process:

![MergingOldStatistics_Example1](https://user-images.githubusercontent.com/12861786/213924101-5a147760-04be-4d46-bfc7-8791d5177db7.png)
![MergingOldStatistics_Example2](https://user-images.githubusercontent.com/12861786/213924111-21705752-3381-4eed-8f98-e188294a3827.png)
![MergingOldStatistics_Example3](https://user-images.githubusercontent.com/12861786/213924118-c953e3d2-c1f0-48bd-bb06-0d68bc26f4f7.png)
