### PR TITLE
Delete old statistics job

### DIFF
--- a/UT4MasterServer/Models/ApplicationSettings.cs
+++ b/UT4MasterServer/Models/ApplicationSettings.cs
@@ -32,6 +32,21 @@ public sealed class ApplicationSettings
 	public List<string> ProxyServers { get; set; } = new List<string>();
 
 	/// <summary>
+	/// Time zone in which deleting old statistics is executed
+	/// </summary>
+	public string DeleteOldStatisticsTimeZone { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Hour at which deleting old statistics is executed
+	/// </summary>
+	public int DeleteOldStatisticsHour { get; set; }
+
+	/// <summary>
+	/// Number of days that statistic records are kept before deleted
+	/// </summary>
+	public int DeleteOldStatisticsBeforeDays { get; set; }
+
+	/// <summary>
 	/// Time zone in which merging old statistics is executed
 	/// </summary>
 	public string MergeOldStatisticsTimeZone { get; set; } = string.Empty;

--- a/UT4MasterServer/Models/ApplicationSettings.cs
+++ b/UT4MasterServer/Models/ApplicationSettings.cs
@@ -30,29 +30,4 @@ public sealed class ApplicationSettings
 	/// IP addresses of trusted proxy servers.
 	/// </summary>
 	public List<string> ProxyServers { get; set; } = new List<string>();
-
-	/// <summary>
-	/// Time zone in which deleting old statistics is executed
-	/// </summary>
-	public string DeleteOldStatisticsTimeZone { get; set; } = string.Empty;
-
-	/// <summary>
-	/// Hour at which deleting old statistics is executed
-	/// </summary>
-	public int DeleteOldStatisticsHour { get; set; }
-
-	/// <summary>
-	/// Number of days that statistic records are kept before deleted
-	/// </summary>
-	public int DeleteOldStatisticsBeforeDays { get; set; }
-
-	/// <summary>
-	/// Time zone in which merging old statistics is executed
-	/// </summary>
-	public string MergeOldStatisticsTimeZone { get; set; } = string.Empty;
-
-	/// <summary>
-	/// Hour at which merging old statistics is executed
-	/// </summary>
-	public int MergeOldStatisticsHour { get; set; }
 }

--- a/UT4MasterServer/Program.cs
+++ b/UT4MasterServer/Program.cs
@@ -9,6 +9,7 @@ using UT4MasterServer.Formatters;
 using UT4MasterServer.Models;
 using UT4MasterServer.Other;
 using UT4MasterServer.Services;
+using UT4MasterServer.Settings;
 
 namespace UT4MasterServer;
 
@@ -53,9 +54,8 @@ public static class Program
 			o.JsonSerializerOptions.Converters.Add(new DateTimeISOJsonConverter());
 		});
 
-		builder.Services.Configure<ApplicationSettings>(
-			builder.Configuration.GetSection("ApplicationSettings")
-		);
+		builder.Services.Configure<ApplicationSettings>(builder.Configuration.GetSection("ApplicationSettings"));
+		builder.Services.Configure<StatisticsSettings>(builder.Configuration.GetSection("StatisticsSettings"));
 
 		builder.Services.Configure<ApplicationSettings>(x =>
 		{

--- a/UT4MasterServer/Services/ApplicationBackgroundService.cs
+++ b/UT4MasterServer/Services/ApplicationBackgroundService.cs
@@ -3,7 +3,7 @@ using UT4MasterServer.Settings;
 
 namespace UT4MasterServer.Services;
 
-public class ApplicationBackgroundCleanupService : IHostedService, IDisposable
+public sealed class ApplicationBackgroundCleanupService : IHostedService, IDisposable
 {
 	private readonly ILogger<ApplicationStartupService> logger;
 	private readonly StatisticsSettings statisticsSettings;

--- a/UT4MasterServer/Settings/StatisticsSettings.cs
+++ b/UT4MasterServer/Settings/StatisticsSettings.cs
@@ -1,0 +1,29 @@
+﻿namespace UT4MasterServer.Settings;
+
+public sealed class StatisticsSettings
+{
+	/// <summary>
+	/// Time zone in which deleting old statistics is executed
+	/// </summary>
+	public string DeleteOldStatisticsTimeZone { get; init; } = string.Empty;
+
+	/// <summary>
+	/// Hour at which deleting old statistics is executed
+	/// </summary>
+	public int DeleteOldStatisticsHour { get; init; }
+
+	/// <summary>
+	/// Number of days that statistic records are kept before deleted
+	/// </summary>
+	public int DeleteOldStatisticsBeforeDays { get; init; }
+
+	/// <summary>
+	/// Time zone in which merging old statistics is executed
+	/// </summary>
+	public string MergeOldStatisticsTimeZone { get; init; } = string.Empty;
+
+	/// <summary>
+	/// Hour at which merging old statistics is executed
+	/// </summary>
+	public int MergeOldStatisticsHour { get; init; }
+}

--- a/UT4MasterServer/appsettings.json
+++ b/UT4MasterServer/appsettings.json
@@ -7,7 +7,9 @@
     "ProxyClientIPHeader": "X-Forwarded-For",
     "ProxyServers": [
       "172.20.0.1"
-    ],
+    ]
+  },
+  "StatisticsSettings": {
     "DeleteOldStatisticsTimeZone": "Central European Standard Time",
     "DeleteOldStatisticsHour": 10,
     "DeleteOldStatisticsBeforeDays": 90,

--- a/UT4MasterServer/appsettings.json
+++ b/UT4MasterServer/appsettings.json
@@ -8,6 +8,9 @@
     "ProxyServers": [
       "172.20.0.1"
     ],
+    "DeleteOldStatisticsTimeZone": "Central European Standard Time",
+    "DeleteOldStatisticsHour": 10,
+    "DeleteOldStatisticsBeforeDays": 90,
     "MergeOldStatisticsTimeZone": "Central European Standard Time",
     "MergeOldStatisticsHour": 10
   },


### PR DESCRIPTION
This background job will delete statistics older than 90 days (configurable)

Related: [#22](https://github.com/timiimit/UT4MasterServer/issues/22)

