### PR TITLE
Bug fixing

### DIFF
--- a/UT4MasterServer/Controllers/ErrorsController.cs
+++ b/UT4MasterServer/Controllers/ErrorsController.cs
@@ -44,7 +44,7 @@ public sealed class ErrorsController : ControllerBase
 					NumericErrorCode = invalidEpicIDException.NumericErrorCode
 				};
 
-				logger.LogError(exception, "Tried using {ID} as EpicID", invalidEpicIDException.ID);
+				logger.LogError(exception, "Tried using {ID} as EpicID.", invalidEpicIDException.ID);
 				return StatusCode(400, err);
 			}
 		}

--- a/UT4MasterServer/Controllers/UnrealTournamentProfileController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentProfileController.cs
@@ -386,6 +386,8 @@ public sealed class UnrealTournamentProfileController : JsonAPIController
 		account.GoldStars = body.NewGoldStars;
 		account.BlueStars = body.NewBlueStars;
 
+		await accountService.UpdateAccountAsync(account);
+
 		// TODO: send out a proper response which is similar to QueryProfile
 
 		return Ok();

--- a/UT4MasterServer/Controllers/UnrealTournamentProfileController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentProfileController.cs
@@ -283,13 +283,21 @@ public sealed class UnrealTournamentProfileController : JsonAPIController
 		const double maxXPPerHour = 500.0;
 		var hoursSinceLastMatch = (DateTime.UtcNow - acc.LastMatchAt).TotalHours;
 
-		var maxEarnableXP = maxXPPerHour * hoursSinceLastMatch;
-		if (body.XPAmount > maxEarnableXP)
-			body.XPAmount = (int)maxEarnableXP;
-
 		// this is just some hard limit on max xp allowed per request/match
 		if (body.XPAmount > 300)
+		{
+			logger.LogWarning("{User} supposedly earned {XP} XP in a single match.", acc.ToString(), body.XPAmount);
 			body.XPAmount = 300;
+		}
+
+		var maxEarnableXP = maxXPPerHour * hoursSinceLastMatch;
+		if (body.XPAmount > maxEarnableXP)
+		{
+			logger.LogWarning("{User} supposedly earned {XP} XP in {Hours} hours. Limiting to {AdjustedXP} XP which is max allowed XP within this timespan.",
+				acc.ToString(), body.XPAmount, hoursSinceLastMatch, maxEarnableXP);
+			body.XPAmount = (int)maxEarnableXP;
+		}
+
 
 
 		var prevXP = acc.XP;

--- a/UT4MasterServer/Controllers/UnrealTournamentWaitTimesController.cs
+++ b/UT4MasterServer/Controllers/UnrealTournamentWaitTimesController.cs
@@ -42,6 +42,6 @@ public sealed class UnrealTournamentWaitTimesController : JsonAPIController
 
 		service.AddWaitTime(ratingType, timeWaited);
 
-		return NotFound();
+		return NoContent();
 	}
 }


### PR DESCRIPTION
Sometimes `InvalidEpicIDException` is thrown in production on `GrantXP` endpoint and it provides no info on what it tries to convert. I added a specialized log message for said exception to be able to find more info regarding this issue.

Other changes:
- Log improbable amounts of earned XP
- Fix QP wait time response
- Fix bug where `SetStars` endpoint never actually updated stored amount of stars in DB