### PR TITLE
Serilog default to warning. Fixes #137

### DIFF
--- a/UT4MasterServer/appsettings.json
+++ b/UT4MasterServer/appsettings.json
@@ -22,6 +22,14 @@
       "Microsoft.AspNetCore": "Error"
     }
   },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+        "System": "Warning"
+      }
+    }
+  },
   "AllowedHosts": "*",
   "Kestrel": {
     "Endpoints": {


### PR DESCRIPTION
Serilog default to warning for base environments. Fixes #137