### PR TITLE
Various front-end bugs

### DIFF
--- a/UT4MasterServer.Web/src/pages/Admin/Accounts/components/ChangePassword.vue
+++ b/UT4MasterServer.Web/src/pages/Admin/Accounts/components/ChangePassword.vue
@@ -70,6 +70,7 @@ import { IAccountWithRoles } from '@/types/account';
 import AdminService from '@/services/admin-service';
 import CryptoJS from 'crypto-js';
 import { Role } from '@/enums/role';
+import { validatePassword } from '@/utils/validation';
 
 const props = defineProps({
   account: {
@@ -89,7 +90,8 @@ const submitAttempted = shallowRef(false);
 const errorMessage = shallowRef(
   'Error changing account password. Please try again.'
 );
-const formValid = computed(() => newPassword.value.length && iAmSure.value);
+const passwordValid = computed(() => validatePassword(newPassword.value));
+const formValid = computed(() => passwordValid.value && iAmSure.value);
 
 // Don't allow changing admin or moderator password
 const disableForm = [Role.Admin, Role.Moderator].some((r) =>

--- a/UT4MasterServer.Web/src/pages/Admin/Accounts/components/ChangePassword.vue
+++ b/UT4MasterServer.Web/src/pages/Admin/Accounts/components/ChangePassword.vue
@@ -92,10 +92,9 @@ const errorMessage = shallowRef(
 const formValid = computed(() => newPassword.value.length && iAmSure.value);
 
 // Don't allow changing admin or moderator password
-const accountIsAdmin = [Role.Admin, Role.Moderator].some((r) =>
+const disableForm = [Role.Admin, Role.Moderator].some((r) =>
   props.account?.roles?.includes(r)
 );
-const disableForm = accountIsAdmin;
 
 async function handleSubmit() {
   submitAttempted.value = true;

--- a/UT4MasterServer.Web/src/pages/Admin/Accounts/components/ChangePassword.vue
+++ b/UT4MasterServer.Web/src/pages/Admin/Accounts/components/ChangePassword.vue
@@ -24,6 +24,13 @@
               autofocus
             />
             <div class="invalid-feedback">New Password is required</div>
+            <div
+              v-if="disableForm"
+              class="invalid-feedback"
+              :class="{ show: disableForm }"
+            >
+              You do not have permission to change this account's password
+            </div>
           </div>
           <div class="col-sm-6 flex-v-center">
             <div class="form-check">
@@ -41,7 +48,11 @@
         </div>
         <div class="form-group row">
           <div class="col-sm-12">
-            <button type="submit" class="btn btn-primary">
+            <button
+              :disabled="disableForm"
+              type="submit"
+              class="btn btn-primary"
+            >
               Change Password
             </button>
           </div>
@@ -52,16 +63,17 @@
 </template>
 
 <script setup lang="ts">
-import { shallowRef, PropType } from 'vue';
+import { shallowRef, PropType, computed } from 'vue';
 import { AsyncStatus } from '@/types/async-status';
 import LoadingPanel from '@/components/LoadingPanel.vue';
-import { IAccount } from '@/types/account';
+import { IAccountWithRoles } from '@/types/account';
 import AdminService from '@/services/admin-service';
 import CryptoJS from 'crypto-js';
+import { Role } from '@/enums/role';
 
 const props = defineProps({
   account: {
-    type: Object as PropType<IAccount>,
+    type: Object as PropType<IAccountWithRoles>,
     required: true
   }
 });
@@ -77,9 +89,19 @@ const submitAttempted = shallowRef(false);
 const errorMessage = shallowRef(
   'Error changing account password. Please try again.'
 );
+const formValid = computed(() => newPassword.value.length && iAmSure.value);
+
+// Don't allow changing admin or moderator password
+const accountIsAdmin = [Role.Admin, Role.Moderator].some((r) =>
+  props.account?.roles?.includes(r)
+);
+const disableForm = accountIsAdmin;
 
 async function handleSubmit() {
   submitAttempted.value = true;
+  if (!formValid.value || disableForm) {
+    return;
+  }
   try {
     status.value = AsyncStatus.BUSY;
     const request = {

--- a/UT4MasterServer.Web/src/services/authentication.service.ts
+++ b/UT4MasterServer.Web/src/services/authentication.service.ts
@@ -78,7 +78,8 @@ export default class AuthenticationService extends HttpService {
       };
       SessionStore.session = session;
     } catch (err: unknown) {
-      this.clearSession();
+      this.logOut();
+      window.location.href = '/';
     }
     const tokenValid =
       SessionStore.session &&

--- a/UT4MasterServer.Web/src/services/http.service.ts
+++ b/UT4MasterServer.Web/src/services/http.service.ts
@@ -1,5 +1,4 @@
 import { SessionStore } from '@/stores/session-store';
-import AuthenticationService from './authentication.service';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -47,20 +46,12 @@ export default class HttpService {
     const response = await fetch(url, fetchOptions);
 
     if (!response.ok) {
-      // Note: Logging the user out on any API request returning 401 may not be the perfect solution,
-      //       there could be a legitimate case for returning 401 that wouldn't require logout,
-      //       but I don't think we have such a case at this point.
-      if (response.status === 401 && SessionStore.isAuthenticated) {
-        new AuthenticationService().logOut();
-        window.location.href = '/';
-      } else {
-        const error = await response.json().catch(() => {
-          console.debug('Unable to parse json response');
-        });
-        const errorMessage = error?.errorMessage ?? error;
-        const defaultErrorMessage = `HTTP request error - ${response.status}: ${response.statusText}`;
-        throw new Error(errorMessage ?? defaultErrorMessage);
-      }
+      const error = await response.json().catch(() => {
+        console.debug('Unable to parse json response');
+      });
+      const errorMessage = error?.errorMessage ?? error;
+      const defaultErrorMessage = `HTTP request error - ${response.status}: ${response.statusText}`;
+      throw new Error(errorMessage ?? defaultErrorMessage);
     }
 
     const responseObj = await response.json().catch(() => {

--- a/UT4MasterServer.Web/src/stores/account-store.ts
+++ b/UT4MasterServer.Web/src/stores/account-store.ts
@@ -1,13 +1,10 @@
-import { TypedStorage } from '@/utils/typed-storage';
 import { ref } from 'vue';
 import { IAccountExtended } from '@/types/account';
 import AccountService from '@/services/account.service';
 import { SessionStore } from './session-store';
 import { Role } from '@/enums/role';
 
-const _account = ref<IAccountExtended | null>(
-  TypedStorage.getItem<IAccountExtended>('account')
-);
+const _account = ref<IAccountExtended | null>(null);
 const _accountService = new AccountService();
 const _adminRoles = [Role.Admin, Role.Moderator];
 
@@ -17,7 +14,6 @@ export const AccountStore = {
   },
   set account(account: IAccountExtended | null) {
     _account.value = account;
-    TypedStorage.setItem<IAccountExtended>('account', account);
   },
   get isAdmin() {
     return _account.value?.roles?.some((r) => _adminRoles.includes(r));


### PR DESCRIPTION
- Account admin allowed for changing of Admin and Moderator passwords, fixed this
- 401s resulted in logout, which was fine until it wasn't. Removed this in favor of only logging a user out when the checkAuth call fails.
- I was storing the user's account in local storage, but this caused a potential error scenario if a user never logged out of 1 account and then created another, they would see the original account information. Removed the local storage, this shouldn't result in considerably more calls to getAccount and avoids the error scenario. The account is still stored in memory so it doesn't call getAccount on page load unless the browser is refreshed.