### PR TITLE
Restart mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
   mongo:
     container_name: mongo
     image: mongo
+    restart: always
     environment:
       - MONGO_INITDB_ROOT_USERNAME=devroot
       - MONGO_INITDB_ROOT_PASSWORD=devroot


### PR DESCRIPTION
This PR makes mongo container restart if it stops.

This should prevent recent incidents when it stops/crashes for an unknown reason. Because our way of rebooting the server causes us to lose logs we have no way of pinpointing exact cause yet. Now if it will auto-restart, logs of container should stay saved which will provide further insight. The downside of this PR is that there's no way for us to know when container stops, hopefully logs will make that clear when it happens.