### PR TITLE
Enforcing EOL Char with Prettier

### DIFF
--- a/UT4MasterServer.Web/package.json
+++ b/UT4MasterServer.Web/package.json
@@ -88,6 +88,7 @@
   "prettier": {
     "trailingComma": "none",
     "semi": true,
-    "singleQuote": true
+    "singleQuote": true,
+    "endOfLine": "lf"
   }
 }

--- a/UT4MasterServer.Web/ut4ms.code-workspace
+++ b/UT4MasterServer.Web/ut4ms.code-workspace
@@ -4,5 +4,7 @@
 			"path": "."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"files.eol": "\n"
+	}
 }


### PR DESCRIPTION
Forcing this setting to prevent flip flopping between CRLF and LF when linux/windows devs commit changes to front end.