### PR TITLE
Added CleanupService for deleting account and all of its related data

### DIFF
--- a/UT4MasterServer.Services/Hosted/ApplicationBackgroundService.cs
+++ b/UT4MasterServer.Services/Hosted/ApplicationBackgroundService.cs
@@ -66,6 +66,9 @@ public sealed class ApplicationBackgroundCleanupService : IHostedService, IDispo
 			if (deleteCount > 0)
 				logger.LogInformation("Background task deleted {DeleteCount} stale game servers.", deleteCount);
 
+			var cleanupService = scope.ServiceProvider.GetRequiredService<CleanupService>();
+			await cleanupService.RemoveNonActivatedAccountsAsync();
+
 			await DeleteOldStatisticsAsync(scope);
 			await MergeOldStatisticsAsync(scope);
 		});

--- a/UT4MasterServer.Services/Scoped/AccountService.cs
+++ b/UT4MasterServer.Services/Scoped/AccountService.cs
@@ -191,6 +191,14 @@ public sealed class AccountService
 		await accountCollection.DeleteOneAsync(user => user.ID == id);
 	}
 
+	public async Task<List<EpicID>> GetNonActivatedAccountsAsync()
+	{
+		var filter = Builders<Account>.Filter.Ne(f => f.Status, AccountStatus.Active) &
+					 Builders<Account>.Filter.Lt(f => f.LastLoginAt, DateTime.UtcNow.AddMonths(1));
+		var accountsIDs = await accountCollection.Find(filter).Project(p => p.ID).ToListAsync();
+		return accountsIDs;
+	}
+
 	public async Task ActivateAccountAsync(EpicID accountID, string guid)
 	{
 		var filter = Builders<Account>.Filter.Eq(f => f.ID, accountID) &

--- a/UT4MasterServer.Services/Scoped/CleanupService.cs
+++ b/UT4MasterServer.Services/Scoped/CleanupService.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Extensions.Logging;
+using UT4MasterServer.Common;
+using UT4MasterServer.Services.Singleton;
+
+namespace UT4MasterServer.Services.Scoped;
+
+public sealed class CleanupService
+{
+	private readonly ILogger<CleanupService> logger;
+	private readonly AccountService accountService;
+	private readonly SessionService sessionService;
+	private readonly CodeService codeService;
+	private readonly FriendService friendService;
+	private readonly CloudStorageService cloudStorageService;
+	private readonly StatisticsService statisticsService;
+	private readonly TrustedGameServerService trustedGameServerService;
+	private readonly RatingsService ratingsService;
+
+	public CleanupService(
+		ILogger<CleanupService> logger,
+		AccountService accountService,
+		SessionService sessionService,
+		CodeService codeService,
+		FriendService friendService,
+		CloudStorageService cloudStorageService,
+		StatisticsService statisticsService,
+		TrustedGameServerService trustedGameServerService,
+		RatingsService ratingsService
+)
+	{
+		this.logger = logger;
+		this.accountService = accountService;
+		this.sessionService = sessionService;
+		this.codeService = codeService;
+		this.friendService = friendService;
+		this.cloudStorageService = cloudStorageService;
+		this.statisticsService = statisticsService;
+		this.trustedGameServerService = trustedGameServerService;
+		this.ratingsService = ratingsService;
+	}
+
+	public async Task RemoveNonActivatedAccountsAsync()
+	{
+		var nonActivatedAccountIds = await accountService.GetNonActivatedAccountsAsync();
+		if (!nonActivatedAccountIds.Any())
+		{
+			return;
+		}
+
+		await RemoveAccountAndRelatedDataAsync(nonActivatedAccountIds);
+	}
+
+	public async Task RemoveAccountAndRelatedDataAsync(List<EpicID> accountIDs)
+	{
+		foreach (var accountID in accountIDs)
+		{
+			await RemoveAccountAndAssociatedDataAsync(accountID);
+		}
+	}
+
+	public async Task RemoveAccountAndAssociatedDataAsync(EpicID accountID)
+	{
+		logger.LogInformation("Deleting account: {AccountID}.", accountID);
+
+		await accountService.RemoveAccountAsync(accountID);
+		await sessionService.RemoveSessionsWithFilterAsync(EpicID.Empty, accountID, EpicID.Empty);
+		await codeService.RemoveAllByAccountAsync(accountID);
+		await cloudStorageService.RemoveAllByAccountAsync(accountID);
+		await statisticsService.RemoveAllByAccountAsync(accountID);
+		await ratingsService.RemoveAllByAccountAsync(accountID);
+		await friendService.RemoveAllByAccountAsync(accountID);
+		await trustedGameServerService.RemoveAllByAccountAsync(accountID);
+		// NOTE: missing removal of account from live servers. this should take care of itself in a relatively short time.
+	}
+}

--- a/UT4MasterServer.Services/Scoped/CleanupService.cs
+++ b/UT4MasterServer.Services/Scoped/CleanupService.cs
@@ -47,10 +47,10 @@ public sealed class CleanupService
 			return;
 		}
 
-		await RemoveAccountAndRelatedDataAsync(nonActivatedAccountIds);
+		await RemoveAccountAndAssociatedDataAsync(nonActivatedAccountIds);
 	}
 
-	public async Task RemoveAccountAndRelatedDataAsync(List<EpicID> accountIDs)
+	public async Task RemoveAccountAndAssociatedDataAsync(List<EpicID> accountIDs)
 	{
 		foreach (var accountID in accountIDs)
 		{

--- a/UT4MasterServer.Services/Scoped/CleanupService.cs
+++ b/UT4MasterServer.Services/Scoped/CleanupService.cs
@@ -42,11 +42,6 @@ public sealed class CleanupService
 	public async Task RemoveNonActivatedAccountsAsync()
 	{
 		var nonActivatedAccountIds = await accountService.GetNonActivatedAccountsAsync();
-		if (!nonActivatedAccountIds.Any())
-		{
-			return;
-		}
-
 		await RemoveAccountAndAssociatedDataAsync(nonActivatedAccountIds);
 	}
 

--- a/UT4MasterServer/Program.cs
+++ b/UT4MasterServer/Program.cs
@@ -115,7 +115,8 @@ public static class Program
 			.AddScoped<MatchmakingService>()
 			.AddScoped<StatisticsService>()
 			.AddScoped<RatingsService>()
-			.AddScoped<AwsSesClient>();
+			.AddScoped<AwsSesClient>()
+			.AddScoped<CleanupService>();
 
 		// services whose instance is created once and are persistent
 		builder.Services


### PR DESCRIPTION
Cleanup service will fetch all accounts that are not in `Active` status and have `LastLoginAt` older than a month, delete them and all of their related data.

Related: [#139](https://github.com/timiimit/UT4MasterServer/issues/139)