### PR TITLE
NuGet update (.NET 6.0.20), fix CVSS 9.8

### DIFF
--- a/.Tests/XUnit.Tests/XUnit.Tests.csproj
+++ b/.Tests/XUnit.Tests/XUnit.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/UT4MasterServer.Authentication/UT4MasterServer.Authentication.csproj
+++ b/UT4MasterServer.Authentication/UT4MasterServer.Authentication.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UT4MasterServer.Authentication/UT4MasterServer.Authentication.csproj
+++ b/UT4MasterServer.Authentication/UT4MasterServer.Authentication.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UT4MasterServer.Common/UT4MasterServer.Common.csproj
+++ b/UT4MasterServer.Common/UT4MasterServer.Common.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
   </ItemGroup>
 
 </Project>

--- a/UT4MasterServer.Services/UT4MasterServer.Services.csproj
+++ b/UT4MasterServer.Services/UT4MasterServer.Services.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UT4MasterServer/UT4MasterServer.csproj
+++ b/UT4MasterServer/UT4MasterServer.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.11" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.15" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />


### PR DESCRIPTION
[Snyk](https://snyk.io/) alerts:
![image](https://github.com/timiimit/UT4MasterServer/assets/905878/7766b6c9-edb2-424a-83c7-0dacc5106e4a)

This fixes critical vulnerability [CVE-2021-26701](https://github.com/advisories/GHSA-ghhp-997w-qr28):
![image](https://github.com/timiimit/UT4MasterServer/assets/905878/1688a94c-5003-4518-a896-f84295063b09)
