### PR TITLE
Optimize docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,5 +27,8 @@ README.md
 # Our rules
 
 **/.github
-OldReferenceCode/**
-Files/Engine.ini
+./OldReferenceCode
+./Files
+./db*
+**/logs
+**/Logs

--- a/.dockerignore
+++ b/.dockerignore
@@ -30,5 +30,5 @@ README.md
 ./OldReferenceCode
 ./Files
 ./db*
-**/logs
-**/Logs
+**/[Ll]og
+**/[Ll]ogs

--- a/UT4MasterServer/Dockerfile
+++ b/UT4MasterServer/Dockerfile
@@ -7,6 +7,11 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["UT4MasterServer/UT4MasterServer.csproj", "UT4MasterServer/"]
+COPY ["UT4MasterServer.Authentication/UT4MasterServer.Authentication.csproj", "UT4MasterServer.Authentication/"]
+COPY ["UT4MasterServer.Common/UT4MasterServer.Common.csproj", "UT4MasterServer.Common/"]
+COPY ["UT4MasterServer.Models/UT4MasterServer.Models.csproj", "UT4MasterServer.Models/"]
+COPY ["UT4MasterServer.Serializers/UT4MasterServer.Serializers.csproj", "UT4MasterServer.Serializers/"]
+COPY ["UT4MasterServer.Services/UT4MasterServer.Services.csproj", "UT4MasterServer.Services/"]
 RUN dotnet restore "UT4MasterServer/UT4MasterServer.csproj"
 COPY . .
 WORKDIR "/src/UT4MasterServer"


### PR DESCRIPTION
There was an issue on hosted server where image building would fail when log/db files used a lot of storage (system ran out of space). This fixes that issue by leaving unneeded files (most notably database and its backups) out of UT4MasterServer's intermediate build stages.

Additionally this fixes the issue where docker was unable to restore all c# projects at the `build` stage.