### PR TITLE
Remove obsolete `version` from `docker-compose.yml`

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ut4masterserver:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ut4masterserver:
     environment:


### PR DESCRIPTION
`version` has been deprecated.

More info:
- https://github.com/docker/compose/issues/11628
- https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element-obsolete